### PR TITLE
Removing monobehaviour injection (no longer needed).

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/DirectionsFactory.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/DirectionsFactory.cs
@@ -18,9 +18,9 @@ namespace Mapbox.Unity.MeshGeneration.Factories
         private Directions _directions;
         public List<MeshModifier> MeshModifiers;
 
-        public override void Initialize(MonoBehaviour mb, IFileSource fileSource)
+        public override void Initialize(IFileSource fileSource)
         {
-            base.Initialize(mb, fileSource);
+            base.Initialize(fileSource);
             _directions = MapboxAccess.Instance.Directions;
         }
 

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/Factory.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/Factory.cs
@@ -8,7 +8,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
     {
         protected IFileSource FileSource;
 
-        public virtual void Initialize(MonoBehaviour mb, IFileSource fileSource)
+        public virtual void Initialize(IFileSource fileSource)
         {
             FileSource = fileSource;
         }

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/MapImageFactory.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/MapImageFactory.cs
@@ -20,9 +20,9 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
         private Dictionary<Vector2, UnityTile> _tiles;
 
-        public override void Initialize(MonoBehaviour mb, IFileSource fs)
+        public override void Initialize(IFileSource fs)
         {
-            base.Initialize(mb, fs);
+            base.Initialize(fs);
             _tiles = new Dictionary<Vector2, UnityTile>();
         }
 

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/MeshFactory.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/MeshFactory.cs
@@ -17,9 +17,9 @@ namespace Mapbox.Unity.MeshGeneration.Factories
         private Dictionary<Vector2, UnityTile> _tiles;
         private Dictionary<string, List<LayerVisualizerBase>> _layerBuilder;
 
-        public override void Initialize(MonoBehaviour mb, IFileSource fs)
+        public override void Initialize(IFileSource fs)
         {
-            base.Initialize(mb, fs);
+            base.Initialize(fs);
             _tiles = new Dictionary<Vector2, UnityTile>();
             _layerBuilder = new Dictionary<string, List<LayerVisualizerBase>>();
             foreach (LayerVisualizerBase factory in Visualizers)

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/TerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/Factories/TerrainFactory.cs
@@ -25,9 +25,9 @@ namespace Mapbox.Unity.MeshGeneration.Factories
         [SerializeField]
         private int sampleCount = 40;
 
-        public override void Initialize(MonoBehaviour mb, IFileSource fs)
+        public override void Initialize(IFileSource fs)
         {
-            base.Initialize(mb, fs);
+            base.Initialize(fs);
             _tiles = new Dictionary<Vector2, UnityTile>();
         }
 

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/MapController.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/MapController.cs
@@ -10,7 +10,6 @@ namespace Mapbox.Unity.MeshGeneration
 
     public class MapController : MonoBehaviour
     {
-        private IFileSource _fileSource;
         public static RectD ReferenceTileRect { get; set; }
         public static float WorldScaleFactor { get; set; }
 
@@ -30,8 +29,7 @@ namespace Mapbox.Unity.MeshGeneration
 
         public void Awake()
         {
-            _fileSource = MapboxAccess.Instance;
-            MapVisualization.Initialize(this, _fileSource);
+            MapVisualization.Initialize(MapboxAccess.Instance);
             _tiles = new Dictionary<Vector2, UnityTile>();
         }
 

--- a/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/MapVisualization.cs
+++ b/sdkproject/Assets/Mapbox/Core/Unity/MeshGeneration/MapVisualization.cs
@@ -12,11 +12,11 @@ namespace Mapbox.Unity.MeshGeneration
     {
         public List<Factory> Factories;
 
-        public void Initialize(MonoBehaviour runner, IFileSource fs)
+        public void Initialize(IFileSource fs)
         {
             foreach (Factory fac in Factories.Where(x => x != null))
             {
-                fac.Initialize(runner, fs);
+                fac.Initialize(fs);
             }
         }
 


### PR DESCRIPTION
Remove monobehaviour injection from factories as we have a better way to run coroutines.