### PR TITLE
publish docs to 'mb-pages'

### DIFF
--- a/scripts/build.csx
+++ b/scripts/build.csx
@@ -211,8 +211,8 @@ if (!publishDocs) {
 			"git add .",
 			$"git commit -m \"pushed via [{originalCommit}] by [{commitAuthor}]\"",
 			$"git remote add origin https://{githubToken}@github.com/{repoName}.git",
-			"git checkout -b gh-pages",
-			"git push -f origin gh-pages"
+			"git checkout -b mb-pages",
+			"git push -f origin mb-pages"
 		});
 		foreach (var cmd in cmds) {
 			if (!RunCommand(cmd)) {


### PR DESCRIPTION
per chat & linking on the main mapbox page https://github.com/mapbox/www.mapbox.com/pull/942#issuecomment-294599111

Let's start pushing docs to `mb-pages` so our docs end up here: https://www.mapbox.com/mapbox-unity-sdk/

@BergWerkGIS just wanted to check this doesn't raise any flags for you
cc @david-rhodes - this will still use appveyor to publish to`mb-pages` branch, and it won't have history