### PR TITLE
Fix for webgl and added additional configuration options

### DIFF
--- a/sdkproject/.gitignore
+++ b/sdkproject/.gitignore
@@ -30,4 +30,5 @@ sysinfo.txt
 
 # Configuration
 /Assets/StreamingAssets/MapboxAccess.*
-/Assets/Resources/MapboxAccess/*
+/Assets/Resources/Mapbox/*
+/Assets/Resources/Mapbox.meta

--- a/sdkproject/.gitignore
+++ b/sdkproject/.gitignore
@@ -30,3 +30,4 @@ sysinfo.txt
 
 # Configuration
 /Assets/StreamingAssets/MapboxAccess.*
+/Assets/Resources/MapboxAccess/*

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
@@ -1,4 +1,3 @@
-using Mapbox.Platform;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
@@ -30,7 +30,7 @@ namespace Mapbox.Platform.Cache
 		private object _lock = new object();
 		private Dictionary<string, CacheItem> _cachedResponses;
 
-
+		// TODO: handle _maxCacheSize of 0!
 		public void Add(string key, byte[] data)
 		{
 			lock (_lock)

--- a/sdkproject/Assets/Mapbox/Unity/Constants.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Constants.cs
@@ -8,11 +8,10 @@ namespace Mapbox.Unity
 			
         public static class Path
         {
-            /// <summary>
-            /// Access token file name. Intended to be located in StreamingAssets.
-            /// </summary>
-            public const string TOKEN_FILE = "MapboxAccess.text";
+			public const string CONFIG_FILE = "MapboxConfiguration.txt";
 			public const string IS_TELEMETRY_ENABLED_KEY = "IS_MAPBOX_TELEMETRY_ENABLED";
+			public static readonly string MAPBOX_RESOURCES_RELATIVE = System.IO.Path.Combine("Mapbox", "MapboxConfiguration");
+			public static readonly string MAPBOX_RESOURCES_ABSOLUTE = System.IO.Path.Combine(System.IO.Path.Combine(Application.dataPath, "Resources"), "Mapbox");
         }
 
         /// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapboxConfigurationWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapboxConfigurationWindow.cs
@@ -1,97 +1,109 @@
 namespace Mapbox.Editor
 {
-    using System.Collections.Generic;
-    using UnityEngine;
-    using UnityEditor;
-    using System.IO;
-    using System.Collections;
-    using Mapbox.Json;
-    using Mapbox.Unity.Utilities;
+	using System.Collections.Generic;
+	using UnityEngine;
+	using UnityEditor;
+	using System.IO;
+	using System.Collections;
+	using Mapbox.Unity;
+	using Mapbox.Json;
+	using Mapbox.Unity.Utilities;
 
-    public class MapboxConfigurationWindow : EditorWindow
-    {
-		static string _accessPath;
-        static string _accessToken;
-        static string _lastAccessToken;
-        static string _validationCode;
+	public class MapboxConfigurationWindow : EditorWindow
+	{
+		static string _configurationFile;
+		static MapboxConfiguration _mapboxConfiguration;
+		static string _accessToken;
+		static int _memoryCacheSize = 500;
 
-        [MenuItem("Mapbox/Configure Access")]
-        static void Init()
-        {
-			_accessPath = Path.Combine(Application.streamingAssetsPath, Mapbox.Unity.Constants.Path.TOKEN_FILE);
+		string _lastAccessToken;
+		string _validationCode;
 
-            Runnable.EnableRunnableInEditor();
-            if (!Directory.Exists(Application.streamingAssetsPath))
-            {
-                Directory.CreateDirectory(Application.streamingAssetsPath);
-            }
-            if (!File.Exists(_accessPath))
-            {
-                File.WriteAllText(_accessPath, _accessToken);
-            }
+		[MenuItem("Mapbox/Configure")]
+		static void Init()
+		{
+			_configurationFile = Path.Combine(Unity.Constants.Path.MAPBOX_RESOURCES_ABSOLUTE, Unity.Constants.Path.CONFIG_FILE);
 
-            _accessToken = File.ReadAllText(_accessPath);
+			Runnable.EnableRunnableInEditor();
+			if (!Directory.Exists(Unity.Constants.Path.MAPBOX_RESOURCES_ABSOLUTE))
+			{
+				Directory.CreateDirectory(Unity.Constants.Path.MAPBOX_RESOURCES_ABSOLUTE);
+			}
+			if (!File.Exists(_configurationFile))
+			{
+				var json = JsonUtility.ToJson(new MapboxConfiguration { AccessToken = "", MemoryCacheSize = _memoryCacheSize });
+				File.WriteAllText(_configurationFile, json);
+			}
+
+			var configurationJson = File.ReadAllText(_configurationFile);
+			_mapboxConfiguration = JsonUtility.FromJson<MapboxConfiguration>(configurationJson);
+			_accessToken = _mapboxConfiguration.AccessToken;
+			_memoryCacheSize = _mapboxConfiguration.MemoryCacheSize;
+
 			var window = (MapboxConfigurationWindow)GetWindow(typeof(MapboxConfigurationWindow));
-            window.Show();
-        }
+			window.Show();
+		}
 
-        void OnGUI()
-        {
-            _accessToken = EditorGUILayout.TextField("Access Token", _accessToken);
-            if (string.IsNullOrEmpty(_accessToken))
-            {
-                EditorGUILayout.HelpBox("You must have an access token!", MessageType.Error);
-                if (GUILayout.Button("Get a token from mapbox.com for free"))
-                {
-                    Application.OpenURL("https://www.mapbox.com/studio/account/tokens/");
-                }
-            }
-            else
-            {
-                if (!string.Equals(_accessToken, _lastAccessToken) || string.IsNullOrEmpty(_validationCode))
-                {
-                    Runnable.Run(ValidateToken(_accessToken));
-                }
+		void OnGUI()
+		{
+			_memoryCacheSize = EditorGUILayout.IntField("Memory Cache Size", _memoryCacheSize);
 
-                var messageType = MessageType.Error;
-                if (string.Equals(_validationCode, "TokenValid"))
-                {
-                    messageType = MessageType.Info;
-                    File.WriteAllText(_accessPath, _accessToken);
-                    EditorGUILayout.HelpBox("TokenValid: saved to /StreamingAssets/MapboxAccess.text", messageType);
-                }
-                else
-                {
-                    EditorGUILayout.HelpBox(_validationCode, messageType);
-                }
-                Repaint();
-            }
-        }
+			_accessToken = EditorGUILayout.TextField("Access Token", _accessToken);
+			if (string.IsNullOrEmpty(_accessToken))
+			{
+				EditorGUILayout.HelpBox("You must have an access token!", MessageType.Error);
+				if (GUILayout.Button("Get a token from mapbox.com for free"))
+				{
+					Application.OpenURL("https://www.mapbox.com/studio/account/tokens/");
+				}
+			}
+			else
+			{
+				if (!string.Equals(_accessToken, _lastAccessToken) || string.IsNullOrEmpty(_validationCode))
+				{
+					Runnable.Run(ValidateToken(_accessToken));
+				}
 
-        IEnumerator ValidateToken(string token)
-        {
-            _lastAccessToken = token;
+				var messageType = MessageType.Error;
+				if (string.Equals(_validationCode, "TokenValid"))
+				{
+					messageType = MessageType.Info;
+					var json = JsonUtility.ToJson(new MapboxConfiguration { AccessToken = _accessToken, MemoryCacheSize = _memoryCacheSize });
+					File.WriteAllText(_configurationFile, json);
+					AssetDatabase.Refresh();
+					EditorGUILayout.HelpBox("TokenValid: saved to " + _configurationFile, messageType);
+				}
+				else
+				{
+					EditorGUILayout.HelpBox(_validationCode, messageType);
+				}
+				Repaint();
+			}
+		}
 
-            // TODO: implement safer url formatting?
-            var www = new WWW("https://api.mapbox.com/tokens/v2?access_token=" + token);
-            while (!www.isDone)
-            {
-                yield return 0;
-            }
-            var json = www.text;
-            if (!string.IsNullOrEmpty(json))
-            {
-                ParseTokenResponse(json);
-            }
-        }
+		IEnumerator ValidateToken(string token)
+		{
+			_lastAccessToken = token;
 
-        void ParseTokenResponse(string json)
-        {
-            var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
-            if (dict.ContainsKey("code"))
-            {
-                _validationCode = dict["code"].ToString();
-            }
-        }
-    }
+			var www = new WWW(Utils.Constants.BaseAPI + "tokens/v2?access_token=" + token);
+			while (!www.isDone)
+			{
+				yield return 0;
+			}
+			var json = www.text;
+			if (!string.IsNullOrEmpty(json))
+			{
+				ParseTokenResponse(json);
+			}
+		}
+
+		void ParseTokenResponse(string json)
+		{
+			var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+			if (dict.ContainsKey("code"))
+			{
+				_validationCode = dict["code"].ToString();
+			}
+		}
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapboxConfigurationWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapboxConfigurationWindow.cs
@@ -46,7 +46,7 @@ namespace Mapbox.Editor
 
 		void OnGUI()
 		{
-			_memoryCacheSize = EditorGUILayout.IntField("Memory Cache Size", _memoryCacheSize);
+			_memoryCacheSize = EditorGUILayout.IntField("Mem Cache Size (# of tiles)", _memoryCacheSize);
 
 			_accessToken = EditorGUILayout.TextField("Access Token", _accessToken);
 			if (string.IsNullOrEmpty(_accessToken))

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -38,9 +38,8 @@ namespace Mapbox.Unity
 
 		MapboxAccess()
 		{
-			ValidateMapboxAccessFile();
 			LoadAccessToken();
-            ConfigureFileSource();
+			ConfigureFileSource();
 			ConfigureTelemetry();
 		}
 
@@ -52,8 +51,8 @@ namespace Mapbox.Unity
 		void ConfigureTelemetry()
 		{
 			// TODO: this will need to be settable at runtime as well? 
-            _isTelemetryEnabled = GetTelemetryCollectionState();
-			
+			_isTelemetryEnabled = GetTelemetryCollectionState();
+
 #if UNITY_EDITOR
 			_telemetryLibrary = TelemetryDummy.Instance;
 #elif UNITY_IOS
@@ -91,51 +90,15 @@ namespace Mapbox.Unity
 		}
 
 
-		private void ValidateMapboxAccessFile()
-		{
-#if !UNITY_ANDROID && !UNITY_WEBGL
-			if (!Directory.Exists(Application.streamingAssetsPath) || !File.Exists(_accessPath))
-			{
-				throw new InvalidTokenException("Please configure your access token in the menu!");
-			}
-#endif
-		}
-
-
 		/// <summary>
-		/// Loads the access token from <see href="https://docs.unity3d.com/Manual/StreamingAssets.html">StreamingAssets</see>.
+		/// Loads the access token from <see href="https://docs.unity3d.com/Manual/BestPracticeUnderstandingPerformanceInUnity6.html">Resources folder</see>.
 		/// </summary>
 		private void LoadAccessToken()
 		{
-#if UNITY_EDITOR || (!UNITY_ANDROID && !UNITY_WEBGL)
-			AccessToken = File.ReadAllText(_accessPath);
-#else
-            AccessToken = LoadMapboxAccess();
-#endif
+			TextAsset taToken = Resources.Load<TextAsset>("MapboxAccess/MapboxAccess");
+			AccessToken = null != taToken ? taToken.text : "";
 		}
 
-
-		/// <summary>
-		/// Android-specific token file loading.
-		/// </summary>
-		private string LoadMapboxAccess()
-		{
-			var request = new WWW(_accessPath);
-
-			// Implement a custom timeout - just in case
-			var timeout = Time.realtimeSinceStartup + 5f;
-			while (!request.isDone)
-			{
-				if (Time.realtimeSinceStartup > timeout)
-				{
-					throw new InvalidTokenException("Could not load access token!");
-				}
-#if !NETFX_CORE
-				System.Threading.Thread.Sleep(10);
-#endif
-			}
-			return request.text;
-		}
 
 		bool GetTelemetryCollectionState()
 		{

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -93,7 +93,7 @@ namespace Mapbox.Unity
 
 		private void ValidateMapboxAccessFile()
 		{
-#if !UNITY_ANDROID
+#if !UNITY_ANDROID && !UNITY_WEBGL
 			if (!Directory.Exists(Application.streamingAssetsPath) || !File.Exists(_accessPath))
 			{
 				throw new InvalidTokenException("Please configure your access token in the menu!");
@@ -107,7 +107,7 @@ namespace Mapbox.Unity
 		/// </summary>
 		private void LoadAccessToken()
 		{
-#if UNITY_EDITOR || !UNITY_ANDROID
+#if UNITY_EDITOR || (!UNITY_ANDROID && !UNITY_WEBGL)
 			AccessToken = File.ReadAllText(_accessPath);
 #else
             AccessToken = LoadMapboxAccess();

--- a/sdkproject/Assets/Resources.meta
+++ b/sdkproject/Assets/Resources.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 4f3329fc919304c67be2b1ff3e03be9d
 folderAsset: yes
-timeCreated: 1496421227
+timeCreated: 1496423104
 licenseType: Pro
 DefaultImporter:
   userData: 

--- a/sdkproject/Assets/Resources.meta
+++ b/sdkproject/Assets/Resources.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: a02832fc8caa0470dac73b464752e9d0
+guid: 4f3329fc919304c67be2b1ff3e03be9d
 folderAsset: yes
-timeCreated: 1490801508
+timeCreated: 1496421227
 licenseType: Pro
 DefaultImporter:
   userData: 


### PR DESCRIPTION
Using `Resources` instead of `StreamingAssets` to force synchronous file loading, which fixes WebGL issue.

Added memory cache size configuration option.

Test on WebGL, iOS, and Android--all appear to work great!