### PR TITLE
Added raycast option for snapping to terrain.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainModifier.cs
@@ -1,36 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
-using Mapbox.Unity.MeshGeneration.Data;
-
-namespace Mapbox.Unity.MeshGeneration.Modifiers
+﻿namespace Mapbox.Unity.MeshGeneration.Modifiers
 {
-    [CreateAssetMenu(menuName = "Mapbox/Modifiers/Snap Terrain Modifier")]
-    public class SnapTerrainModifier : MeshModifier
-    {
-        public override ModifierType Type { get { return ModifierType.Preprocess; } }
+	using UnityEngine;
+	using Mapbox.Unity.MeshGeneration.Data;
 
-        public override void Run(VectorFeatureUnity feature, MeshData md, UnityTile tile = null)
-        {
-            if (md.Vertices.Count > 0)
-            {
-                for (int i = 0; i < md.Vertices.Count; i++)
-                {
-                    var h = tile.QueryHeightData((float)((md.Vertices[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x), (float)((md.Vertices[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
-                    md.Vertices[i] += new Vector3(0, h, 0);
-                }
-            }
-            else
-            {
-                foreach (var sub in feature.Points)
-                {
-                    for (int i = 0; i < sub.Count; i++)
-                    {
-                        var h = tile.QueryHeightData((float)((sub[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x), (float)((sub[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
-                        sub[i] += new Vector3(0, h, 0);
-                    }
-                }
-            }
-        }
-    }
+	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Snap Terrain Modifier")]
+	public class SnapTerrainModifier : MeshModifier
+	{
+		public override ModifierType Type { get { return ModifierType.Preprocess; } }
+
+		public override void Run(VectorFeatureUnity feature, MeshData md, UnityTile tile = null)
+		{
+			if (md.Vertices.Count > 0)
+			{
+				for (int i = 0; i < md.Vertices.Count; i++)
+				{
+					var h = tile.QueryHeightData((float)((md.Vertices[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x), (float)((md.Vertices[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
+					md.Vertices[i] += new Vector3(0, h, 0);
+				}
+			}
+			else
+			{
+				foreach (var sub in feature.Points)
+				{
+					for (int i = 0; i < sub.Count; i++)
+					{
+						var h = tile.QueryHeightData((float)((sub[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x), (float)((sub[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
+						sub[i] += new Vector3(0, h, 0);
+					}
+				}
+			}
+		}
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainRaycastModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainRaycastModifier.cs
@@ -1,0 +1,78 @@
+﻿namespace Mapbox.Unity.MeshGeneration.Modifiers
+{
+	using Mapbox.Unity.Map;
+	using Mapbox.Unity.MeshGeneration.Data;
+	using UnityEngine;
+
+	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Snap Terrain Raycast Modifier")]
+	public class SnapTerrainRaycastModifier : MeshModifier
+	{
+		private const int RAY_LENGTH = 50;
+
+		[SerializeField]
+		private LayerMask _terrainMask;
+
+		public override ModifierType Type
+		{
+			get { return ModifierType.Preprocess; }
+		}
+
+		public override void Run(VectorFeatureUnity feature, MeshData md, UnityTile tile = null)
+		{
+			// TODO: Get this from tile as IMapReadable.
+			float worldScale = FindObjectOfType<AbstractMap>().WorldRelativeScale;
+
+			if (md.Vertices.Count > 0)
+			{
+				for (int i = 0; i < md.Vertices.Count; i++)
+				{
+					var h = tile.QueryHeightData((float)((md.Vertices[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x),
+						(float)((md.Vertices[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
+
+					RaycastHit hit;
+					Vector3 rayCenter =
+						new Vector3(md.Vertices[i].x * worldScale + tile.transform.position.x,
+							h * worldScale + RAY_LENGTH / 2,
+							md.Vertices[i].z * worldScale + tile.transform.position.z);
+
+					if (Physics.Raycast(rayCenter, Vector3.down, out hit, RAY_LENGTH, _terrainMask))
+					{
+						md.Vertices[i] += new Vector3(0, hit.point.y / worldScale, 0);
+					}
+					else
+					{
+						// Raycasting sometimes fails at terrain boundaries, fallback to tile height data.
+						md.Vertices[i] += new Vector3(0, h, 0);
+					}
+				}
+			}
+			else
+			{
+				foreach (var sub in feature.Points)
+				{
+					for (int i = 0; i < sub.Count; i++)
+					{
+						var h = tile.QueryHeightData((float)((sub[i].x + tile.Rect.Size.x / 2) / tile.Rect.Size.x),
+							(float)((sub[i].z + tile.Rect.Size.y / 2) / tile.Rect.Size.y));
+
+						RaycastHit hit;
+						Vector3 rayCenter =
+							new Vector3(sub[i].x * worldScale + tile.transform.position.x,
+								h * worldScale + RAY_LENGTH / 2,
+								sub[i].z * worldScale + tile.transform.position.z);
+
+						if (Physics.Raycast(rayCenter, Vector3.down, out hit, RAY_LENGTH, _terrainMask))
+						{
+							sub[i] += new Vector3(0, hit.point.y / worldScale, 0);
+						}
+						else
+						{
+							// Raycasting sometimes fails at terrain boundaries, fallback to tile height data.
+							sub[i] += new Vector3(0, h, 0);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainRaycastModifier.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/SnapTerrainRaycastModifier.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 41aa014e797344c2c99c979bad017646
+timeCreated: 1492732222
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is slower but more accurate than standard snapping.

Helps fix: https://github.com/mapbox/mapbox-unity-sdk/issues/100.