### PR TITLE
Parent tiles to root, even on device. 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/MapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/MapVisualizer.cs
@@ -111,12 +111,7 @@ namespace Mapbox.Unity.MeshGeneration
 			if (unityTile == null)
 			{
 				unityTile = new GameObject().AddComponent<UnityTile>();
-
-#if !UNITY_EDITOR
-				unityTile.transform.localScale = Unity.Constants.Math.Vector3One * _map.WorldRelativeScale;
-#else
 				unityTile.transform.SetParent(_map.Root, false);
-#endif
 			}
 
 			unityTile.Initialize(_map, tileId);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -102,7 +102,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			_rect = Conversions.TileBounds(tileId);
 			_canonicalTileId = tileId.Canonical;
 			gameObject.name = tileId.ToString();
-			var position = new Vector3((float)(Rect.Center.x - map.CenterMercator.x), 0, (float)(Rect.Center.y - map.CenterMercator.y));
+			var position = new Vector3((float)(_rect.Center.x - map.CenterMercator.x), 0, (float)(_rect.Center.y - map.CenterMercator.y));
 			transform.localPosition = position;
 			gameObject.SetActive(true);
 		}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -101,13 +101,8 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			_relativeScale = 1 / Mathf.Cos(Mathf.Deg2Rad * (float)map.CenterLatitudeLongitude.x);
 			_rect = Conversions.TileBounds(tileId);
 			_canonicalTileId = tileId.Canonical;
-			var position = new Vector3((float)(Rect.Center.x - map.CenterMercator.x), 0, (float)(Rect.Center.y - map.CenterMercator.y));
-
-#if !UNITY_EDITOR
-			position *= map.WorldRelativeScale;
-#else
 			gameObject.name = tileId.ToString();
-#endif
+			var position = new Vector3((float)(Rect.Center.x - map.CenterMercator.x), 0, (float)(Rect.Center.y - map.CenterMercator.y));
 			transform.localPosition = position;
 			gameObject.SetActive(true);
 		}


### PR DESCRIPTION
Removing editor specific parenting and positioning logic. This was intended as a performance optimization, but it is confusing and leads to bugs.