### PR TITLE
use string.Equals for testing mesh type filters

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -14,7 +14,7 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 
         public override bool Try(VectorFeatureUnity feature)
         {
-            var check = _type.ToLowerInvariant().Contains(feature.Properties["type"].ToString().ToLowerInvariant());
+            var check = _type.ToLowerInvariant().Equals(feature.Properties["type"].ToString().ToLowerInvariant());
             return _behaviour == TypeFilterType.Include ? check : !check;
         }
 


### PR DESCRIPTION
Hey folks! This is a quick fix for filters on mesh generation!

Currently, when adding a `TypeFilter` to a `VectorLayerVisualizer`, that filter will partially match types because the filter is using `string.Contains` for a check.

So if you add a filter to exclude `building:part`, this will end up excluding all `building` types in addition to `building:part`, because of the partially matching strings.

I'm not sure if that was the intended behavior or not, but since a `VectorLayerVisualizer` can have multiple filters, I don't think there is a strong reason to keep the "partial matching".

Let me know if I'm off-base, or can adjust anything!

---

By the way, thanks a ton for all the work going into this SDK. I've been working on a game with a few folks, and we're using it heavily! 🎉 