### PR TITLE
check for duplicate Android libraries on prebuild step

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_Android_prebuild_checks.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_Android_prebuild_checks.cs
@@ -1,0 +1,85 @@
+﻿namespace Mapbox.Unity.Editor
+{
+
+	using System;
+	using System.IO;
+	using System.Linq;
+	using System.Collections;
+	using System.Collections.Generic;
+	using UnityEngine;
+	using UnityEditor;
+	using UnityEditor.Build;
+	using System.Text;
+
+
+	/// <summary>
+	/// Simple pre-build script to check for duplicate Android libraries
+	/// </summary>
+	public class PreBuildChecksEditor : IPreprocessBuild
+	{
+		public int callbackOrder { get { return 0; } }
+		public void OnPreprocessBuild(BuildTarget target, string path)
+		{
+
+			if (BuildTarget.Android != target)
+			{
+				return;
+			}
+
+			Debug.Log("Mapbox prebuild checks for target '" + target);
+
+			List<LibInfo> libInfo = new List<LibInfo>();
+			foreach (var file in Directory.GetFiles(Application.dataPath, "*.jar", SearchOption.AllDirectories))
+			{
+				libInfo.Add(new LibInfo(file));
+			}
+			foreach (var file in Directory.GetFiles(Application.dataPath, "*.aar", SearchOption.AllDirectories))
+			{
+				libInfo.Add(new LibInfo(file));
+			}
+
+			var stats = libInfo.GroupBy(li => li.BaseFileName).OrderBy(g => g.Key);
+
+			StringBuilder sb = new StringBuilder();
+			foreach (var s in stats)
+			{
+				if (s.Count() > 1)
+				{
+					sb.AppendLine(string.Format(
+						"{0}:{1}{2}"
+						, s.Key
+						, Environment.NewLine
+						, string.Join(Environment.NewLine, s.Select(li => "\t" + li.AssetPath).ToArray())
+					));
+				}
+			}
+			if (sb.Length > 0)
+			{
+				Debug.LogErrorFormat("DUPLICATE ANDROID PLUGINS FOUND - BUILD WILL MOST LIKELY FAIL!!!{0}Resolve to continue.{0}{1}", Environment.NewLine, sb);
+			}
+		}
+
+
+
+		private class LibInfo
+		{
+			public LibInfo(string fullPath)
+			{
+				FullPath = fullPath;
+				FullFileName = Path.GetFileName(fullPath);
+				// TODO: find a better way to extract base file name
+				// Mapbox telemetry lib uses different naming that other android libs
+				// <name>-<major>.<minor>.<patch> vs. <name>-<major>-<minor>-<patch>
+				// okio-1.13.0, support-v4-25.1.0 vs. mapbox-android-telemetry-2-1-0
+				BaseFileName = FullFileName.Substring(0, FullFileName.LastIndexOf("-"));
+				AssetPath = fullPath.Replace(Application.dataPath.Replace("Assets", ""), "");
+			}
+
+			public string FullPath { get; private set; }
+			public string FullFileName { get; private set; }
+			public string BaseFileName { get; private set; }
+			public string AssetPath { get; private set; }
+		}
+
+	}
+}


### PR DESCRIPTION
Simple prebuild script that scans for duplicate Android libraries:

![image](https://user-images.githubusercontent.com/4549888/28711928-8319d9e4-7389-11e7-91e5-54a35ef812df.png)

Maybe we revisit `Google jar-resolver` again later, refs #136 