### PR TITLE
Catch exceptions when parsing Android library file names

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_Android_prebuild_checks.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_Android_prebuild_checks.cs
@@ -34,11 +34,25 @@
 			List<AndroidLibInfo> libInfo = new List<AndroidLibInfo>();
 			foreach (var file in Directory.GetFiles(Application.dataPath, "*.jar", SearchOption.AllDirectories))
 			{
-				libInfo.Add(new AndroidLibInfo(file));
+				try
+				{
+					libInfo.Add(new AndroidLibInfo(file));
+				}
+				catch
+				{
+					Debug.LogWarningFormat("could not extract version from file name: [{0}]", file);
+				}
 			}
 			foreach (var file in Directory.GetFiles(Application.dataPath, "*.aar", SearchOption.AllDirectories))
 			{
-				libInfo.Add(new AndroidLibInfo(file));
+				try
+				{
+					libInfo.Add(new AndroidLibInfo(file));
+				}
+				catch
+				{
+					Debug.LogWarningFormat("could not extract version from file name: [{0}]", file);
+				}
 			}
 
 			var stats = libInfo.GroupBy(li => li.BaseFileName).OrderBy(g => g.Key);


### PR DESCRIPTION
refs https://github.com/mapbox/mapbox-unity-sdk/issues/204#issuecomment-322697997

Extracting version numbers out of Android library names is fragile as they might follow naming schemes different than Google's Android Support Libraries.

Catch exceptions on parsing and log as warnings.