### PR TITLE
Mesh.GetVertices and Mesh.GetNormals do not exist in Unity 5.5.0 and 5.5.1

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
@@ -200,7 +200,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		/// <param name="heightMultiplier">Multiplier for queried height value</param>
 		private void GenerateTerrainMesh(UnityTile tile)
 		{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
             tile.MeshFilter.mesh.GetVertices(_currentTileMeshData.Vertices);
             tile.MeshFilter.mesh.GetNormals(_currentTileMeshData.Normals);
 #else
@@ -273,7 +273,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 		private void ResetToFlatMesh(UnityTile tile)
 		{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
             tile.MeshFilter.mesh.GetVertices(_currentTileMeshData.Vertices);
             tile.MeshFilter.mesh.GetNormals(_currentTileMeshData.Normals);
 #else
@@ -309,7 +309,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			var cap = _sampleCount - 1;
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -339,7 +339,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_meshData.TryGetValue(tileId.South, out _stitchTarget);
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -369,7 +369,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_meshData.TryGetValue(tileId.West, out _stitchTarget);
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -402,7 +402,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -435,7 +435,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -455,7 +455,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -480,7 +480,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -505,7 +505,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
                 _stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
                 _stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
@@ -215,7 +215,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		/// <param name="heightMultiplier">Multiplier for queried height value</param>
 		private void GenerateTerrainMesh(UnityTile tile)
 		{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 			tile.MeshFilter.mesh.GetVertices(_currentTileMeshData.Vertices);
 			tile.MeshFilter.mesh.GetNormals(_currentTileMeshData.Normals);
 #else
@@ -285,7 +285,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 		private void ResetToFlatMesh(UnityTile tile)
 		{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 			tile.MeshFilter.mesh.GetVertices(_currentTileMeshData.Vertices);
 			tile.MeshFilter.mesh.GetNormals(_currentTileMeshData.Normals);
 #else
@@ -322,7 +322,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_meshData.TryGetValue(tileId.North, out _stitchTarget);
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -349,7 +349,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_meshData.TryGetValue(tileId.South, out _stitchTarget);
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -376,7 +376,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_meshData.TryGetValue(tileId.West, out _stitchTarget);
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -404,7 +404,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -432,7 +432,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -457,7 +457,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -482,7 +482,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else
@@ -507,7 +507,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			if (_stitchTarget != null)
 			{
-#if UNITY_5_5_OR_NEWER
+#if (UNITY_5_5_OR_NEWER && !UNITY_5_5_0 && !UNITY_5_5_1)
 				_stitchTarget.GetVertices(_stitchTargetMeshData.Vertices);
 				_stitchTarget.GetNormals(_stitchTargetMeshData.Normals);
 #else


### PR DESCRIPTION
Mesh.GetVertices and Mesh.GetNormals were [introduced in Unity 5.5.2](https://unity3d.com/es/unity/whats-new/unity-5.5.2) so Versions 5.5.0 and 5.5.1 should be excluded.