### PR TITLE
Update Map.cs

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Map.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Map.cs
@@ -229,8 +229,7 @@ namespace Mapbox.Map
 
 				tile.Initialize(param, () => { this.NotifyNext(tile); });
 
-				this.tiles.Add(tile);
-				this.NotifyNext(tile);
+				this.tiles.Add(tile);				
 			}
 		}
 	}


### PR DESCRIPTION
At the bottom of this script it calls NotifyNext() as a callback from the tile.Initialize() and again right after.
I'm getting duplicate tiles when running Mapbox RasterMap demo. 
Steps to get bug.
Create empty gameobject
Attach RasterMap to object and press play.
Stop and play again.
From now on you will have 2 of each tile.