### PR TITLE
Memory Leak Cleanup

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -235,5 +235,14 @@ namespace Mapbox.Unity.MeshGeneration.Data
 				_tiles[i].Cancel();
 			}
 		}
-	}
+
+        private void OnDestroy()
+        {
+            Cancel();
+            if (_heightTexture != null)
+                Destroy(_heightTexture);
+            if (_rasterData != null)
+                Destroy(_rasterData);
+        }
+    }
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
@@ -269,9 +269,19 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			{
 				_meshData.Add(tile.UnwrappedTileId, tile.MeshFilter.mesh);
 			}
-		}
 
-		private void ResetToFlatMesh(UnityTile tile)
+            if (_addCollider)
+            {
+                var meshCollider = tile.Collider as MeshCollider;
+                if (meshCollider)
+                {
+                    meshCollider.sharedMesh = tile.MeshFilter.mesh;
+                }
+            }
+
+        }
+
+        private void ResetToFlatMesh(UnityTile tile)
 		{
 #if UNITY_5_5_OR_NEWER
             tile.MeshFilter.mesh.GetVertices(_currentTileMeshData.Vertices);


### PR DESCRIPTION
If you destroy the map tiles you will leak memory.  This tweak fixes the leak.  There maybe other locations in the code leaking Texture2Ds but this is the one we ran across using elevated terrain. 

Collider Fix makes LowPolyTerrain match your Terrain file in that it correctly adds the mesh to the collider. Otherwise the collider does not work.  