### PR TITLE
Added check to latitude/longitude coordinates

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -1,6 +1,7 @@
 ﻿namespace Mapbox.Unity.Map
 {
 	using System;
+	using System.Globalization;
 	using Mapbox.Unity.Utilities;
 	using Utils;
 	using UnityEngine;
@@ -128,7 +129,20 @@
 			if (_initializeOnStart)
 			{
 				var latLonSplit = _latitudeLongitudeString.Split(',');
-				Initialize(new Vector2d(double.Parse(latLonSplit[0]), double.Parse(latLonSplit[1])), _zoom);
+
+				double latitude, longitude;
+				CultureInfo locale = CultureInfo.CreateSpecificCulture ("en-US");
+				var hasError = !double.TryParse (latLonSplit [0], NumberStyles.Any, locale, out latitude);
+				hasError = hasError || !double.TryParse (latLonSplit [1], NumberStyles.Any, locale, out longitude);
+
+				if (!hasError)
+				{
+					Initialize (new Vector2d (latitude, longitude), _zoom);
+				} 
+				else 
+				{
+					Debug.LogErrorFormat("Invalid latitude and longitude coordinates: \"{0}\"", _latitudeLongitudeString);
+				}
 			}
 		}
 


### PR DESCRIPTION
I thought of adding something very simple that's been bugging me for a while. 

Since my laptop's locale is not English at home, I have to change `AbstractMap` when trying to generate a map every to adapt to my locale. So I added a check that basically that basically checks if the coordinates are in the format `0.000, 0.000`. 

This format makes sense for most coordinates (I tried `0,000, 0,000` and it looks very awkward).