### PR TITLE
Add transparency shader for raster tilers

### DIFF
--- a/sdkproject/Assets/Mapbox/Shaders.meta
+++ b/sdkproject/Assets/Mapbox/Shaders.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ce8bcb7ed11f64e35aa8cd9056463e21
+folderAsset: yes
+timeCreated: 1509042932
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader
+++ b/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader
@@ -1,0 +1,87 @@
+﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "Mapbox/Raster With Transparency" 
+{
+	Properties 
+	{
+		_Color ("Color", Color) = (1,1,1,1)
+		_MainTex ("Albedo (RGB)", 2D) = "blue" {}
+		_Alpha ("Alpha", Float) = 1
+	}
+
+	Category
+	{
+		Tags { "Queue"="Transparent" "RenderType"="Transparent" }
+		Blend SrcAlpha OneMinusSrcAlpha
+		Cull Off Lighting Off ZWrite Off
+
+		SubShader 
+		{		
+			Pass
+			{
+				BindChannels 
+				{
+					Bind "Color", color
+					Bind "Vertex", vertex
+					Bind "TexCoord", texcoord
+				}
+
+				CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+			    #pragma multi_compile_particles
+				#pragma fragmentoption ARB_precision_hint_fastest
+
+				#include "UnityCG.cginc"
+
+				// Use shader model 3.0 target, to get nicer looking lighting
+				#pragma target 3.0
+
+				sampler2D _MainTex;
+				float _Alpha;
+				float4 _MainTex_ST;
+								
+				fixed4 _Color;
+
+				struct vertexIn
+				{
+					float4 vertex			: POSITION;
+					float4 texcoord			: TEXCOORD0;
+					fixed4 color			: COLOR;
+				};
+			
+				struct vertexOut 
+				{
+					float4 pos				: SV_POSITION;
+					float2 uv				: UV_COORD0;
+					float4 color			: COLOR;
+					float2 screenspaceUv	: UV_COORD1;
+				};
+
+				vertexOut vert(vertexIn v)
+				{
+					vertexOut o;
+					o.pos = UnityObjectToClipPos (v.vertex);
+					o.color = v.color * _Color;
+					o.uv = v.texcoord.xy;
+					o.screenspaceUv = o.pos.xy;
+					return o;
+				}
+
+				fixed4 frag(vertexOut o) : SV_Target
+				{
+					float2 uv = TRANSFORM_TEX(o.uv, _MainTex);
+					fixed4 texColor = tex2D(_MainTex, uv);
+					
+					fixed4 color = o.color * texColor;
+					color.a =  ((texColor.r + texColor.g + texColor.b) * 0.33333f + _Color.a) * _Alpha;
+
+					return color;
+				}
+		 
+				ENDCG
+			}
+		}
+	} 
+	FallBack "Diffuse"
+}

--- a/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader
+++ b/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader
@@ -74,7 +74,8 @@ Shader "Mapbox/Raster With Transparency"
 					fixed4 texColor = tex2D(_MainTex, uv);
 					
 					fixed4 color = o.color * texColor;
-					color.a =  ((texColor.r + texColor.g + texColor.b) * 0.33333f + _Color.a) * _Alpha;
+                    float threshold = step((texColor.r + texColor.g + texColor.b) * 0.33333f,0.1);
+					color.a =  (1 - ((threshold) * (1 -_Color.a))) * _Alpha;
 
 					return color;
 				}

--- a/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader.meta
+++ b/sdkproject/Assets/Mapbox/Shaders/RasterWithTransparencyShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4cff8ad2a7f4c41aa929f127a4b62f87
+timeCreated: 1509042938
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This shader allows for custom mapbox studio styles to exclude data types/regions by using the color "black." For example, you could make a label style with white labels and a black background. In Unity, with this shader applied to the material assigned in the `TerrainFactory`, only the labels will be visible.