### PR TITLE
Reverting the unity layer to match up with file names and types in the submodule

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/StyleOptimizedVectorTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/StyleOptimizedVectorTile.cs
@@ -44,7 +44,7 @@ namespace Mapbox.Map
 	{
 		// FIXME: Namespace here is very confusing and conflicts (sematically)
 		// with his class. Something has to be renamed here.
-		private Mapbox.VectorTile.VectorTileData data;
+		private Mapbox.VectorTile.VectorTile data;
 
 		string _optimizedStyleId;
 
@@ -54,7 +54,7 @@ namespace Mapbox.Map
 
 		/// <summary> Gets the vector decoded using Mapbox.VectorTile library. </summary>
 		/// <value> The GeoJson data. </value>
-		public Mapbox.VectorTile.VectorTileData Data
+		public Mapbox.VectorTile.VectorTile Data
 		{
 			get
 			{
@@ -177,7 +177,7 @@ namespace Mapbox.Map
 			try
 			{
 				var decompressed = Compression.Decompress(data);
-				this.data = new Mapbox.VectorTile.VectorTileData(decompressed);
+				this.data = new Mapbox.VectorTile.VectorTile(decompressed);
 
 				return true;
 			}

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/VectorTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/VectorTile.cs
@@ -42,13 +42,13 @@ namespace Mapbox.Map {
 	public sealed class VectorTile : Tile, IDisposable {
 		// FIXME: Namespace here is very confusing and conflicts (sematically)
 		// with his class. Something has to be renamed here.
-		private Mapbox.VectorTile.VectorTileData data;
+		private Mapbox.VectorTile.VectorTile data;
 
 		private bool isDisposed = false;
 
 		/// <summary> Gets the vector decoded using Mapbox.VectorTile library. </summary>
 		/// <value> The GeoJson data. </value>
-		public Mapbox.VectorTile.VectorTileData Data {
+		public Mapbox.VectorTile.VectorTile Data {
 			get {
 				return this.data;
 			}
@@ -152,7 +152,7 @@ namespace Mapbox.Map {
 		internal override bool ParseTileData(byte[] data) {
 			try {
 				var decompressed = Compression.Decompress(data);
-				this.data = new Mapbox.VectorTile.VectorTileData(decompressed);
+				this.data = new Mapbox.VectorTile.VectorTile(decompressed);
 
 				return true;
 			}

--- a/sdkproject/Assets/Resources.meta
+++ b/sdkproject/Assets/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4f3329fc919304c67be2b1ff3e03be9d
+folderAsset: yes
+timeCreated: 1502482928
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is to undo changes to the repo to match up with [the revert](https://github.com/mapbox/vector-tile-cs/commit/8a200f74157080a92d9c71c2efdc57fff7cb4e10) suggested by @BergWerkGIS 
