### PR TITLE
add FeatureBehaviourModifier

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/FeatureBehaviourModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/FeatureBehaviourModifier.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdf79806a4f74da4aa48339c010a208c, type: 3}
+  m_Name: FeatureBehaviourModifier
+  m_EditorClassIdentifier: 
+  Active: 1

--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/FeatureBehaviourModifier.asset.meta
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/FeatureBehaviourModifier.asset.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 69c9fbc203d6e934ea944041d43ea709
+timeCreated: 1509395647
+licenseType: Pro
+NativeFormatImporter:
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Components/FeatureBehaviour.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Components/FeatureBehaviour.cs
@@ -7,12 +7,34 @@ namespace Mapbox.Unity.MeshGeneration.Components
 
 	public class FeatureBehaviour : MonoBehaviour
 	{
-		public Transform Transform { get; set; }
+		public VectorEntity VectorEntity;
+		public Transform Transform;
 		public VectorFeatureUnity Data;
 
 		public void ShowDebugData()
 		{
 			DataString = string.Join("\r\n", Data.Properties.Select(x => x.Key + " - " + x.Value.ToString()).ToArray());
+		}
+
+		public void ShowDataPoints()
+		{
+			foreach (var item in VectorEntity.Feature.Points)
+			{
+				for (int i = 0; i < item.Count; i++)
+				{
+					var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+					go.name = i.ToString();
+					go.transform.SetParent(transform, false);
+					go.transform.localPosition = item[i];
+				}
+			}
+		}
+
+		internal void Initialize(VectorEntity ve)
+		{
+			VectorEntity = ve;
+			Transform = transform;
+			Data = ve.Feature;
 		}
 
 		[Multiline(5)]

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/FeatureBehaviourModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/FeatureBehaviourModifier.cs
@@ -1,0 +1,15 @@
+﻿namespace Mapbox.Unity.MeshGeneration.Modifiers
+{
+	using Mapbox.Unity.MeshGeneration.Data;
+	using Mapbox.Unity.MeshGeneration.Components;
+	using UnityEngine;
+
+	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Add Feature Behaviour Modifier")]
+	public class FeatureBehaviourModifier : GameObjectModifier
+	{
+		public override void Run(VectorEntity ve, UnityTile tile)
+		{
+			ve.GameObject.AddComponent<FeatureBehaviour>().Initialize(ve);
+		}
+	}
+}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/FeatureBehaviourModifier.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/FeatureBehaviourModifier.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fdf79806a4f74da4aa48339c010a208c
+timeCreated: 1499897465
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
feature behaviour isn't added to all object by default since last performance merge. and feature behaviour is our only way to keep data on gameobjects so this PR adds a new game object modifier to make that happen again.
what to test;
-open any scene/graph
-choose any non-merged stack and add FeatureBehaviourModifier to GameObject Modifier
-run project, select objects and see FeatureBehaviour script on the inspector, click show properties to check if it's showing
