### PR TITLE
node editor improvements

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/NodeEditor/ConnectionPoint.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/NodeEditor/ConnectionPoint.cs
@@ -47,7 +47,14 @@ namespace Mapbox.Editor.NodeEditor
 
 		public ConnectionPoint(Node node, string inname, string name, float deltay, ConnectionPointType type, GUIStyle style)
 		{
-			this._outLabel = Regex.Replace(name, "(\\B[A-Z])", " $1");
+			if (!string.IsNullOrEmpty(name))
+			{
+				this._outLabel = Regex.Replace(name, "(\\B[A-Z])", " $1");
+			}
+			else
+			{
+				this._outLabel = "";
+			}
 			inLabel = inname;
 			this.node = node;
 			this.type = type;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/NodeEditor/NodeBasedEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/NodeEditor/NodeBasedEditor.cs
@@ -199,7 +199,7 @@ namespace Mapbox.Editor.NodeEditor
 
 		void OnFocus()
 		{
-			//Parse();
+			Parse();
 		}
 
 		private void DrawGrid(float gridSpacing, float gridOpacity, Color gridColor)

--- a/sdkproject/Assets/Mapbox/Unity/Editor/ScriptableCreatorWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/ScriptableCreatorWindow.cs
@@ -4,6 +4,7 @@
 	using UnityEditor;
 	using System.Collections.Generic;
 	using System;
+	using System.Linq;
 
 	public class ScriptableCreatorWindow : EditorWindow
 	{
@@ -69,9 +70,9 @@
 					var asset = AssetDatabase.LoadAssetAtPath(ne, _type) as ScriptableObject;
 					_assets.Add(asset);
 				}
+				_assets = _assets.OrderBy(x => x.GetType().Name).ThenBy(x => x.name).ToList();
 			}
-
-
+			
 			var st = new GUIStyle();
 			st.padding = new RectOffset(15, 15, 15, 15);
 			scrollPos = EditorGUILayout.BeginScrollView(scrollPos, st);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/VectorLayerVisualizerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/VectorLayerVisualizerEditor.cs
@@ -147,10 +147,10 @@
 
 				EditorGUILayout.Space();
 				EditorGUILayout.BeginHorizontal();
+				SerializedProperty sp;
 				if (GUILayout.Button(new GUIContent("Add New Empty"), (GUIStyle)"minibuttonleft"))
 				{
 					facs.arraySize++;
-					facs.GetArrayElementAtIndex(facs.arraySize - 1).objectReferenceValue = null;
 				}
 				if (GUILayout.Button(new GUIContent("Find Asset"), (GUIStyle)"minibuttonright"))
 				{

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -186,5 +186,6 @@
 		}
 
 		public abstract void Initialize(Vector2d latLon, int zoom);
+
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -73,13 +73,7 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 					filter.Initialize();
 				}
 			}
-			foreach (var item in Stacks)
-			{
-				if (item != null && item.Stack != null)
-				{
-					item.Stack.Initialize();
-				}
-			}
+			
 			if (_defaultStack != null)
 			{
 				_defaultStack.Initialize();


### PR DESCRIPTION
add "update on focus" to node editor
fix null ref exceptions on adding new empty scriptable object field
fix a bug where mod stacks with empty key causing errors in editor window
remove duplicate initialize loop in layer visualizer

to test, check each layer in node editor (map vis to mod stack), add remove stuff, change/clear/modify key values, occasionally click on node editor window to see it update etc.

this PR should fix #316 quick but non-optimal way