### PR TITLE
Aborted messages are now logged as warnings, rather than errors.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
@@ -48,32 +48,30 @@
 
 			if (errors.Count > 0)
 			{
-				Debug.LogError(String.Format(
-					"{0} Exception(s) caused on the tile. Tile ID:{1} Tile Type:{4}{2}{3}"
-					, errors.Count
-					, e.TileId
-					, Environment.NewLine
-					, string.Join(Environment.NewLine, errors.Select(ex => ex.Message).ToArray())
-					, e.TileType
-				));
+				Debug.LogError(printMessage(errors, e));
 			}
 
 			if (warnings.Count > 0)
 			{
-				Debug.LogWarning(String.Format(
-					"{0} Exception(s) caused on the tile. Tile ID:{1} Tile Type:{4}{2}{3}"
-					, warnings.Count
-					, e.TileId
-					, Environment.NewLine
-					, string.Join(Environment.NewLine, warnings.Select(ex => ex.Message).ToArray())
-					, e.TileType
-				));
+				Debug.LogWarning(printMessage(warnings, e));
 			}
 
 			if (OnTileError != null)
 			{
 				OnTileError.Invoke(e);
 			}
+		}
+
+		private string printMessage(List<Exception> exceptions, TileErrorEventArgs e)
+		{
+			return string.Format(
+				"{0} Exception(s) caused on the tile. Tile ID:{1} Tile Type:{4}{2}{3}"
+				, exceptions.Count
+				, e.TileId
+				, Environment.NewLine
+				, string.Join(Environment.NewLine, exceptions.Select(ex => ex.Message).ToArray())
+				, e.TileType
+			);
 		}
 
 		void OnDisable()

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace Mapbox.Unity.Map
 {
 	using System;
+	using System.Collections.Generic;
 	using System.Linq;
 	using Mapbox.Map;
 	using Mapbox.Unity.Map;
@@ -30,19 +31,44 @@
 
 		private void _OnTileErrorHandler(object sender, TileErrorEventArgs e)
 		{
+			var errors = new List<Exception>();
+			var warnings = new List<Exception>();
 
-			if (e.Exceptions.Count > 0)
+			foreach (var exception in e.Exceptions)
+			{
+				if (exception.Message.Contains("Request aborted"))
+				{
+					warnings.Add(exception);
+				}
+				else
+				{
+					errors.Add(exception);
+				}
+			}
+
+			if (errors.Count > 0)
 			{
 				Debug.LogError(String.Format(
 					"{0} Exception(s) caused on the tile. Tile ID:{1} Tile Type:{4}{2}{3}"
-					, e.Exceptions.Count
+					, errors.Count
 					, e.TileId
 					, Environment.NewLine
-					, string.Join(Environment.NewLine, e.Exceptions.Select(ex => ex.Message).ToArray())
+					, string.Join(Environment.NewLine, errors.Select(ex => ex.Message).ToArray())
 					, e.TileType
 				));
 			}
 
+			if (warnings.Count > 0)
+			{
+				Debug.LogWarning(String.Format(
+					"{0} Exception(s) caused on the tile. Tile ID:{1} Tile Type:{4}{2}{3}"
+					, warnings.Count
+					, e.TileId
+					, Environment.NewLine
+					, string.Join(Environment.NewLine, warnings.Select(ex => ex.Message).ToArray())
+					, e.TileType
+				));
+			}
 
 			if (OnTileError != null)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileErrorHandler.cs
@@ -31,29 +31,20 @@
 
 		private void _OnTileErrorHandler(object sender, TileErrorEventArgs e)
 		{
-			var errors = new List<Exception>();
-			var warnings = new List<Exception>();
-
-			foreach (var exception in e.Exceptions)
+			// check if request has been aborted: show warning not error
+			if (e.Exceptions.Count > 0)
 			{
-				if (exception.Message.Contains("Request aborted"))
+				// aborted is always the first exception
+				// additional exceptions are always caused by the request being aborted
+				// show all of them as warnings
+				if (e.Exceptions[0].Message.Contains("Request aborted"))
 				{
-					warnings.Add(exception);
+					Debug.LogWarning(printMessage(e.Exceptions, e));
 				}
 				else
 				{
-					errors.Add(exception);
+					Debug.LogError(printMessage(e.Exceptions, e));
 				}
-			}
-
-			if (errors.Count > 0)
-			{
-				Debug.LogError(printMessage(errors, e));
-			}
-
-			if (warnings.Count > 0)
-			{
-				Debug.LogWarning(printMessage(warnings, e));
 			}
 
 			if (OnTileError != null)


### PR DESCRIPTION
To test, load `QuadTreeLoader` scene and change the pan speed to some high value (8). Clear your cache, play, then pan non-stop for quite some time. You should see aborted messages as warnings and missing tiles as exceptions.