### PR TITLE
Fix for tile providers not requesting tiles again 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/CameraBoundsTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/CameraBoundsTileProvider.cs
@@ -37,6 +37,7 @@ namespace Mapbox.Unity.Map
 			_groundPlane = new Plane(Vector3.up, Mapbox.Unity.Constants.Math.Vector3Zero);
 			_viewportTarget = new Vector3(0.5f, 0.5f, 0);
 			_shouldUpdate = true;
+			_cachedTile = new UnwrappedTileId();
 		}
 
 		void Update()

--- a/sdkproject/Assets/Mapbox/Unity/Map/RangeAroundTransformTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/RangeAroundTransformTileProvider.cs
@@ -32,6 +32,7 @@
 			{
 				_initialized = true;
 			}
+			_cachedTile = new UnwrappedTileId();
 		}
 
 		private void Update()


### PR DESCRIPTION
Caused when reinitializing a map object but not updating lat/lon of tile provider.