### PR TITLE
Add utility function to Map to convert from a world-point to Lat/Long.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -214,7 +214,7 @@
 
 		public Vector2d getGeoPositionOfWorldPoint(Vector3 realworldPoint)
 		{
-			return (Quaternion.Inverse(this.transform.rotation) * (realworldPoint - this.transform.position)).GetGeoPosition(this.CenterMercator, this.WorldRelativeScale);
+			return (Quaternion.Inverse(_root.rotation) * (realworldPoint - _root.position)).GetGeoPosition(this.CenterMercator, this.WorldRelativeScale);
 		}
 
 		public abstract void Initialize(Vector2d latLon, int zoom);

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -212,6 +212,11 @@
 			OnInitialized();
 		}
 
+		public Vector2d getGeoPositionOfWorldPoint(Vector3 realworldPoint)
+		{
+			return (Quaternion.Inverse(this.transform.rotation) * (realworldPoint - this.transform.position)).GetGeoPosition(this.CenterMercator, this.WorldRelativeScale);
+		}
+
 		public abstract void Initialize(Vector2d latLon, int zoom);
 	}
 }


### PR DESCRIPTION
For all 4 of my 4 PRs:
I made these modifications to the mapbox-unity-sdk for my own project. I'm not sure if they are useful to pull into the official build as other people might find them useful? 

It's possible there's another way of doing these things, in which case please let me know!

At the very least, hopefully it's useful to know how users are using your SDK.

---

This PR adds a way to go from a point in world space (which I happen to be getting via a ray-cast), and convert it to a Lat/Long on a map (that may be rotated / translated - eg. an ARAlignedMap).