### PR TITLE
Add ability to read the heightModifier of terrain so it is possible t…

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
@@ -32,7 +32,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		[SerializeField]
 		private string _mapId = "";
 		[SerializeField]
-		private float _heightModifier = 1f;
+		public float _heightModifier = 1f;
 		[SerializeField]
 		[Range(2, 256)]
 		private int _sampleCount = 40;
@@ -97,12 +97,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_newNormalList = new List<Vector3>(_sampleCount * _sampleCount);
 			_newUvList = new List<Vector2>(_sampleCount * _sampleCount);
 			_newTriangleList = new List<int>();
-		}
-
-		// Had to add this as we need a way of getting what was set in the Inspector so we can calculate real-life altitude.
-		public float GetHeightModifier()
-		{
-			return _heightModifier;
 		}
 
 		internal override void OnRegistered(UnityTile tile)

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
@@ -99,6 +99,12 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_newTriangleList = new List<int>();
 		}
 
+		// Had to add this as we need a way of getting what was set in the Inspector so we can calculate real-life altitude.
+		public float GetHeightModifier()
+		{
+			return _heightModifier;
+		}
+
 		internal override void OnRegistered(UnityTile tile)
 		{
 			if (_addToLayer && tile.gameObject.layer != _layerId)


### PR DESCRIPTION
…o calculate altitude from the mesh.

---

I had a point on a map collider (from a ray-cast), and needed to know the altitude at that point. But I was displaying terrain with heightModifier set to 3, so point.y was 3x larger that the real-life altitude. Since this value was set in the unity inspector and is private, it's not possible to know what to divide by.