### PR TITLE
Cache the last location update so that it can be read without waiting…

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Location/AbstractLocationProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Location/AbstractLocationProvider.cs
@@ -5,10 +5,12 @@
 
 	public abstract class AbstractLocationProvider : MonoBehaviour, ILocationProvider
 	{
+		public Location _latestLocation;
 		public event Action<Location> OnLocationUpdated = delegate { };
 
 		protected virtual void SendLocation(Location location)
 		{
+			_latestLocation = location;
 			OnLocationUpdated(location);
 		}
 	}

--- a/sdkproject/Assets/Mapbox/Unity/Location/LocationProviderFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Location/LocationProviderFactory.cs
@@ -39,7 +39,7 @@ namespace Mapbox.Unity.Location
 			}
 		}
 
-		ILocationProvider _defaultLocationProvider;
+		AbstractLocationProvider _defaultLocationProvider;
 
 		/// <summary>
 		/// The default location provider. 
@@ -58,7 +58,7 @@ namespace Mapbox.Unity.Location
 		/// }
 		/// </code>
 		/// </example>
-		public ILocationProvider DefaultLocationProvider
+		public AbstractLocationProvider DefaultLocationProvider
 		{
 			get
 			{
@@ -73,7 +73,7 @@ namespace Mapbox.Unity.Location
 		/// <summary>
 		/// Returns the serialized <see cref="T:Mapbox.Unity.Location.TransformLocationProvider"/>.
 		/// </summary>
-		public ILocationProvider TransformLocationProvider
+		public AbstractLocationProvider TransformLocationProvider
 		{
 			get
 			{
@@ -84,7 +84,7 @@ namespace Mapbox.Unity.Location
 		/// <summary>
 		/// Returns the serialized <see cref="T:Mapbox.Unity.Location.EditorLocationProvider"/>.
 		/// </summary>
-		public ILocationProvider EditorLocationProvider
+		public AbstractLocationProvider EditorLocationProvider
 		{
 			get
 			{
@@ -95,7 +95,7 @@ namespace Mapbox.Unity.Location
 		/// <summary>
 		/// Returns the serialized <see cref="T:Mapbox.Unity.Location.DeviceLocationProvider"/>
 		/// </summary>
-		public ILocationProvider DeviceLocationProvider
+		public AbstractLocationProvider DeviceLocationProvider
 		{
 			get
 			{


### PR DESCRIPTION
… for a new LocationUpdate.

---

Adding a delegate hander to LocationUpdate is fine most of the time, but if you are in a newly created service and immediately want to know the most recent known location, there is no way to get it. This adds a cache of the most recent value to AbstractLocationProvider.

Possibly it would be better to rename this new variable to _currentLocation and refactor subclasses to use that (With my change I think the location gets cached in AbstractLocationProvider AND the subclasses). Also perhaps a getter is better than a public variable?