### PR TITLE
Replace 'mapbox/satellite-v9' with 'mapbox.satellite'

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/SatelliteImageFactory.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/SatelliteImageFactory.asset
@@ -11,13 +11,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b10536479dade041b6db9893fdf723a, type: 3}
   m_Name: SatelliteImageFactory
   m_EditorClassIdentifier: 
-  _mapIdType: 0
+  _mapIdType: 1
   _customStyle:
     Name: 
     Id: mapbox.satellite
     Modified: 
     UserName: 
-  _mapId: mapbox://styles/mapbox/satellite-v9
+  _mapId: mapbox.satellite
   _useCompression: 0
   _useMipMap: 0
   _useRetina: 0

--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/SatelliteImageFactory.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/SatelliteImageFactory.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b10536479dade041b6db9893fdf723a, type: 3}
   m_Name: SatelliteImageFactory
   m_EditorClassIdentifier: 
-  _mapIdType: 1
+  _mapIdType: 0
   _customStyle:
     Name: 
     Id: mapbox.satellite

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapImageFactoryEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapImageFactoryEditor.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Editor
 		"mapbox://styles/mapbox/outdoors-v10",
 		"mapbox://styles/mapbox/dark-v9",
 		"mapbox://styles/mapbox/light-v9",
-		"mapbox://styles/mapbox/satellite-v9",
+		"mapbox.satellite",
 		"mapbox://styles/mapbox/satellite-streets-v10"};
 
 		private string[] _basicMapNames = new string[6] {


### PR DESCRIPTION
fixes #386 

Defaulted SatelliteImageFactory to `mapbox.satellite` instead of `mapbox/satellite-v9`.

@david-rhodes could you please check if this is enough of a fix or something else is needed?