### PR TITLE
Fix for duplicate keys in slippy maps

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/MapAtSpecificLocation.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/MapAtSpecificLocation.cs
@@ -19,6 +19,8 @@ namespace Mapbox.Unity.Map
 			_worldRelativeScale = (float)(_unityTileSize / referenceTileRect.Size.x);
 
 			// The magic line.
+			// Because this offsets the map root, you must manually compensate for this offset with any future
+			// conversion operations (lat/lon <--> unity world space)!!!
 			_root.localPosition = -Conversions.GeoToWorldPosition(_centerLatitudeLongitude.x, _centerLatitudeLongitude.y, _centerMercator, _worldRelativeScale).ToVector3xz();
 
 			_mapVisualizer.Initialize(this, _fileSource);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/StyleOptimizedVectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/StyleOptimizedVectorTileFactory.cs
@@ -116,6 +116,18 @@
 			// We are no longer interested in this tile's notifications.
 			tile.OnHeightDataChanged -= DataChangedHandler;
 			tile.OnRasterDataChanged -= DataChangedHandler;
+
+			// clean up any pending request for this tile
+			if (_cachedData.ContainsKey(tile))
+			{
+				Progress--;
+				_cachedData.Remove(tile);
+			}
+
+			foreach (var vis in Visualizers)
+			{
+				vis.UnregisterTile(tile);
+			}
 		}
 
 		private void DataChangedHandler(UnityTile t)
@@ -160,7 +172,7 @@
 
 			_cachedData.Remove(tile);
 		}
-		
+
 		private void DecreaseProgressCounter()
 		{
 			Progress--;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -76,7 +76,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			var vectorTile = new VectorTile();
 			tile.AddTile(vectorTile);
 
-			
+
 			vectorTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
 				if (vectorTile.HasError)
@@ -123,6 +123,13 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			// We are no longer interested in this tile's notifications.
 			tile.OnHeightDataChanged -= DataChangedHandler;
 			tile.OnRasterDataChanged -= DataChangedHandler;
+
+			// clean up any pending request for this tile
+			if (_cachedData.ContainsKey(tile))
+			{
+				Progress--;
+				_cachedData.Remove(tile);
+			}
 
 			foreach (var vis in Visualizers)
 			{


### PR DESCRIPTION
Ensure we remove tiles that have not yet been fetched (cancelled).

Fixes #345