### PR TITLE
null Error Handling for GeocodeAttributeSearchWindow

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -129,10 +129,6 @@
 			{
 				_features = res.Features;
 			}
-			else
-			{
-				_features.Clear();
-			}
 			_isSearching = false;
 			this.Repaint();
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -129,8 +129,12 @@
 			{
 				_features = res.Features;
 			}
+			else
+			{
+				_features.Clear();
+			}
 			_isSearching = false;
-			this.Repaint ();
+			this.Repaint();
 
 			//_hasResponse = true;
 			//_coordinate = res.Features[0].Center;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -125,9 +125,11 @@
 
 		void HandleGeocoderResponse(ForwardGeocodeResponse res)
 		{
-			_features = res.Features;
+			if (res != null) {
+				_features = res.Features;
+			}
 			_isSearching = false;
-			this.Repaint();
+			this.Repaint ();
 
 			//_hasResponse = true;
 			//_coordinate = res.Features[0].Center;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -125,7 +125,8 @@
 
 		void HandleGeocoderResponse(ForwardGeocodeResponse res)
 		{
-			if (res != null) {
+			if (res != null)
+			{
 				_features = res.Features;
 			}
 			_isSearching = false;


### PR DESCRIPTION
This is just a little `NullReferenceException` handling for `GeocodeAttributeSearchWindow`. I found it very frustrating when the search failed but when the UI was indicating otherwise.

I was thinking of investing the possible cases where the `ForwardGeocodeResponse` response can be `null` on `HandleGeocoderResponse` in order to provide better feedback than "No results found".