### PR TITLE
Modified how QuadTreeCameraMovements dispatches input events

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/Scripts/QuadTreeCameraMovement.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/QuadTreeCameraMovement.cs
@@ -46,7 +46,7 @@
 		{
 			if (null == _dynamicZoomMap) { return; }
 
-			if (Input.touchSupported)
+			if (Input.touchSupported && Input.touchCount > 0)
 			{
 				HandleTouch();
 			}


### PR DESCRIPTION
This hardly requires a new branch/PR but hopefully it can save someone many hours of digging...like it took me :(

I've been working in the Unity Engine with Mapbox for the past couple of days, using the dynamic map and everything works great. However when I went to build to WebGL for embedding in the browser, I was unable to move the map. After doing some digging I found that what was happening is that the browser handles touch events separately from mousedown events. 

In the QuadTreeCameraMovement.cs script:
```cs
private void LateUpdate()
{
	if (null == _dynamicZoomMap) { return; }

	if (Input.touchSupported)
	{
		HandleTouch();
	}
	else
	{
		HandleMouseAndKeyBoard();
	}
}
```

It seems that `Input.touchSupported` is resolving to true and stepping into `HandleTouch()` but then inside that function:

```cs
void HandleTouch()
{
	float zoomFactor = 0.0f;
	//pinch to zoom. 
	switch (Input.touchCount)
	{
		case 1:
			{
				PanMapUsingTouchOrMouse();
			}
			break;
		case 2:
			{
				// Store both touches.
				Touch touchZero = Input.GetTouch(0);
				Touch touchOne = Input.GetTouch(1);

			        // Find the position in the previous frame of each touch.
				Vector2 touchZeroPrevPos = touchZero.position - touchZero.deltaPosition;
				Vector2 touchOnePrevPos = touchOne.position - touchOne.deltaPosition;

				// Find the magnitude of the vector (the distance) between the touches in each frame.
				float prevTouchDeltaMag = (touchZeroPrevPos - touchOnePrevPos).magnitude;
				float touchDeltaMag = (touchZero.position - touchOne.position).magnitude;
			// Find the difference in the distances between each frame.
				zoomFactor = 0.01f * (touchDeltaMag - prevTouchDeltaMag);
			}
			ZoomMapUsingTouchOrMouse(zoomFactor);
			break;
		default:
			break;
	}
}
```

The mouse clicks aren't being interpreted as touch events so `Input.touchCount` always = 0, the switch is immediately breaking out without updating the map. 

What I've done to fix the issue is to simply add another conditional in the `LateUpdate()` function to check the amount of touch inputs as well:

```cs
private void LateUpdate()
{
	if (null == _dynamicZoomMap) { return; }

	if (Input.touchSupported && Input.touchCount > 0)
	{
		HandleTouch();
	}
	else
	{
		HandleMouseAndKeyBoard();
	}
}
```

This way, the inputs will always get dispatched to `HandleMouseAndKeyBoard()` until absolutely necessary.

## ***Only tested for webGL***