### PR TITLE
Fixes #285 (validate token in MapboxAccess)

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -9,6 +9,7 @@ namespace Mapbox.Unity
 	using Mapbox.Unity.Telemetry;
 	using Mapbox.Map;
 	using Mapbox.MapMatching;
+	using Mapbox.Tokens;
 
 	/// <summary>
 	/// Object for retrieving an API token and making http requests.
@@ -37,24 +38,16 @@ namespace Mapbox.Unity
 		}
 
 
+		MapboxConfiguration _configuration;
 		/// <summary>
 		/// The Mapbox API access token. 
 		/// See <see href="https://www.mapbox.com/mapbox-unity-sdk/docs/01-mapbox-api-token.html">Mapbox API Congfiguration in Unity</see>.
 		/// </summary>
-		MapboxConfiguration _configuration;
 		public MapboxConfiguration Configuration
 		{
 			get
 			{
 				return _configuration;
-			}
-			private set
-			{
-				if (value == null)
-				{
-					throw new InvalidTokenException("Please configure your access token from the Mapbox menu!");
-				}
-				_configuration = value;
 			}
 		}
 
@@ -67,6 +60,19 @@ namespace Mapbox.Unity
 
 		public void SetConfiguration(MapboxConfiguration configuration)
 		{
+			if (configuration == null)
+			{
+				throw new InvalidTokenException("Please configure your access token from the Mapbox menu!");
+			}
+
+			TokenValidator.Retrieve(configuration.AccessToken, (response) =>
+			{
+				if (response.Status != MapboxTokenStatus.TokenValid)
+				{
+					throw new InvalidTokenException(response.Status.ToString());
+				}
+			});
+
 			_configuration = configuration;
 		}
 
@@ -90,9 +96,9 @@ namespace Mapbox.Unity
 		{
 			TextAsset configurationTextAsset = Resources.Load<TextAsset>(Constants.Path.MAPBOX_RESOURCES_RELATIVE);
 #if !WINDOWS_UWP
-			Configuration = configurationTextAsset == null ? null : JsonUtility.FromJson<MapboxConfiguration>(configurationTextAsset.text);
+			SetConfiguration(configurationTextAsset == null ? null : JsonUtility.FromJson<MapboxConfiguration>(configurationTextAsset.text));
 #else
-			Configuration = configurationTextAsset == null ? null : Mapbox.Json.JsonConvert.DeserializeObject<MapboxConfiguration>(configurationTextAsset.text);
+			SetConfiguration(configurationTextAsset == null ? null : Mapbox.Json.JsonConvert.DeserializeObject<MapboxConfiguration>(configurationTextAsset.text));
 #endif
 		}
 
@@ -159,10 +165,10 @@ namespace Mapbox.Unity
 		}
 
 
+		Geocoder _geocoder;
 		/// <summary>
 		/// Lazy geocoder.
 		/// </summary>
-		Geocoder _geocoder;
 		public Geocoder Geocoder
 		{
 			get
@@ -176,10 +182,10 @@ namespace Mapbox.Unity
 		}
 
 
+		Directions _directions;
 		/// <summary>
 		/// Lazy Directions.
 		/// </summary>
-		Directions _directions;
 		public Directions Directions
 		{
 			get
@@ -192,10 +198,10 @@ namespace Mapbox.Unity
 			}
 		}
 
+		MapMatcher _mapMatcher;
 		/// <summary>
 		/// Lazy Map Matcher.
 		/// </summary>
-		MapMatcher _mapMatcher;
 		public MapMatcher MapMatcher
 		{
 			get
@@ -207,6 +213,24 @@ namespace Mapbox.Unity
 				return _mapMatcher;
 			}
 		}
+
+
+		MapboxTokenApi _tokenValidator;
+		/// <summary>
+		/// Lazy token validator.
+		/// </summary>
+		public MapboxTokenApi TokenValidator
+		{
+			get
+			{
+				if (_tokenValidator == null)
+				{
+					_tokenValidator = new MapboxTokenApi();
+				}
+				return _tokenValidator;
+			}
+		}
+
 
 		class InvalidTokenException : Exception
 		{

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -74,6 +74,9 @@ namespace Mapbox.Unity
 			});
 
 			_configuration = configuration;
+
+			ConfigureFileSource();
+			ConfigureTelemetry();
 		}
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/DebugTools.meta
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/DebugTools.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: d5e1c6b7d1367a6499dae6c38bf2a085
+guid: c2f9985805e6d4227a776425b7c33ca4
 folderAsset: yes
-timeCreated: 1510755854
+timeCreated: 1512101271
 licenseType: Pro
 DefaultImporter:
   userData: 


### PR DESCRIPTION
Throw exception on invalid token.

For cleanup, we should utilize this in the configuration window as well, but that should wait until those refactors are done.