### PR TITLE
add null ref check to data callbacks, coroutine start in VectorLayerV…

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/3_VoxelMap/Scripts/VoxelTile.cs
+++ b/sdkproject/Assets/Mapbox/Examples/3_VoxelMap/Scripts/VoxelTile.cs
@@ -172,8 +172,15 @@ namespace Mapbox.Examples.Voxels
 				}
 			}
 
-			_camera.transform.position = new Vector3(_tileWidthInVoxels * .5f, 2f, _tileWidthInVoxels * .5f);
-			StartCoroutine(BuildRoutine());
+			if (_camera != null)
+			{
+				_camera.transform.position = new Vector3(_tileWidthInVoxels * .5f, 2f, _tileWidthInVoxels * .5f);
+			}
+
+			if (this != null)
+			{
+				StartCoroutine(BuildRoutine());
+			}
 		}
 
 		IEnumerator BuildRoutine()

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -212,6 +212,10 @@ namespace Mapbox.Unity.MeshGeneration.Data
 
 		public void SetRasterData(byte[] data, bool useMipMap, bool useCompression)
 		{
+			if (MeshRenderer == null || MeshRenderer.material == null)
+			{
+				return;
+			}
 			// Don't leak the texture, just reuse it.
 			if (_rasterData == null)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/LowPolyTerrainFactory.cs
@@ -196,6 +196,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			pngRasterTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+
 				if (pngRasterTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId, pngRasterTile.GetType(), tile, pngRasterTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
@@ -88,6 +88,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			Progress++;
 			rasterTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+
 				if (rasterTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId,rasterTile.GetType(),tile, rasterTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/StyleOptimizedVectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/StyleOptimizedVectorTileFactory.cs
@@ -78,6 +78,11 @@
 			Progress++;
 			vectorTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+
 				if (vectorTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId, vectorTile.GetType(), tile, vectorTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactory.cs
@@ -202,6 +202,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			pngRasterTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+				
 				if (pngRasterTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId, pngRasterTile.GetType(), tile, pngRasterTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryWithSideWalls.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryWithSideWalls.cs
@@ -270,6 +270,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			pngRasterTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+
 				if (pngRasterTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId, pngRasterTile.GetType(), tile, pngRasterTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -89,6 +89,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 			vectorTile.Initialize(_fileSource, tile.CanonicalTileId, _mapId, () =>
 			{
+				if (tile == null)
+				{
+					return;
+				}
+
 				if (vectorTile.HasError)
 				{
 					OnErrorOccurred(new TileErrorEventArgs(tile.CanonicalTileId, vectorTile.GetType(), tile, vectorTile.Exceptions));

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -116,6 +116,11 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 			//HACK to prevent request finishing on same frame which breaks modules started/finished events 
 			yield return null;
 
+			if (tile == null)
+			{
+				yield break;
+			}
+
 			//testing each feature with filters
 			var fc = layer.FeatureCount();
 			var filterOut = false;


### PR DESCRIPTION
…isualizer and voxel tile

added null checks to bunch of places. nothing crazy, most of them are data callbacks where I think null check is normal. another one is in vector layer visualizer where coroutines start, again I think it makes sense as rest of the mesh gen won't work if it's null this way. then had 2 in voxel tile file.

factory and layer visualizer thing should prevent most (if not all) NREs we're having now. I felt feature gameobject based NREs are still possible but we also check it in modifier stack where we choose which game object to use (create new one or use cached objecst which is null checked), still that part feels a little weak.

to test, clear cache (better to give it time to load stuff) frequently and spam scene and main buttons in "main" test scene.