### PR TITLE
Submesh fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/AdminLayer/ExplorerAdminHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/AdminLayer/ExplorerAdminHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 3
   _createSideWalls: 1
+  _separateSubmesh: 1

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/BarrierLine/ExplorerBarrierHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/BarrierLine/ExplorerBarrierHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 1
   _createSideWalls: 1
+  _separateSubmesh: 1

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/BuildingLayer/ExplorerFlatTopHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/BuildingLayer/ExplorerFlatTopHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 0
   _height: 0
   _createSideWalls: 1
+  _separateSubmesh: 1

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/ExplorerHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/ExplorerHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 0
   _height: 0
   _createSideWalls: 1
+  _separateSubmesh: 1

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/HillshadeLayer/ExplorerHillshadeHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/HillshadeLayer/ExplorerHillshadeHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 3
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LandcoverLayer/ExplorerLandCoverHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LandcoverLayer/ExplorerLandCoverHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 2
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LanduseLayer/ExplorerLanduseHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LanduseLayer/ExplorerLanduseHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 0.2
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LanduseOverlayLayer/ExplorerLanduseOverlayHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/LanduseOverlayLayer/ExplorerLanduseOverlayHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 0.5
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/RoadLayer/ExplorerRoadHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/RoadLayer/ExplorerRoadHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 0.5
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/TrafficLayer/LowTraffic/ExplorerTrafficHeight.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/TrafficLayer/LowTraffic/ExplorerTrafficHeight.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 1
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/WaterLayer/ExplorerWaterHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/1_Explorer/Modules/WaterLayer/ExplorerWaterHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 0.4
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/DirectionsHeight.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/DirectionsHeight.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 4
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/FixedHeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/FixedHeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 1
   _height: 1
   _createSideWalls: 0
+  _separateSubmesh: 0

--- a/sdkproject/Assets/Mapbox/Examples/_sharedModules/HeightModifier.asset
+++ b/sdkproject/Assets/Mapbox/Examples/_sharedModules/HeightModifier.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   _forceHeight: 0
   _height: 0
   _createSideWalls: 1
+  _separateSubmesh: 1

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/MaterialModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/MaterialModifier.cs
@@ -21,13 +21,21 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		{
 			var min = Math.Min(_materials.Length, ve.MeshFilter.mesh.subMeshCount);
 			var mats = new Material[min];
-			for (int i = 0; i < min; i++)
-			{
-				mats[i] = _materials[i].Materials[UnityEngine.Random.Range(0, _materials[i].Materials.Length)];
-			}
 
-			if (_projectMapImagery)
+			if (!_projectMapImagery)
 			{
+				for (int i = 0; i < min; i++)
+				{
+					mats[i] = _materials[i].Materials[UnityEngine.Random.Range(0, _materials[i].Materials.Length)];
+				}
+			}
+			else
+			{
+				for (int i = 0; i < min; i++)
+				{
+					mats[i] = Instantiate(_materials[i].Materials[UnityEngine.Random.Range(0, _materials[i].Materials.Length)]);
+				}
+
 				mats[0].mainTexture = tile.GetRasterData();
 				mats[0].mainTextureScale = new Vector2(1f, 1f);
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
@@ -32,11 +32,14 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		[Tooltip("Fixed height value for ForceHeight option")]
 		private float _height;
 		private float _scale = 1;
-		private bool _separateSubmesh = false;
 
 		[SerializeField]
 		[Tooltip("Create side walls from calculated height down to terrain level. Suggested for buildings, not suggested for roads.")]
 		private bool _createSideWalls = true;
+
+		[SerializeField]
+		[Tooltip("Create side walls as separate submesh.")]
+		private bool _separateSubmesh = true;
 
 		public override ModifierType Type { get { return ModifierType.Preprocess; } }
 
@@ -117,7 +120,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 				_counter = md.Edges.Count;
 				var wallTri = new List<int>(_counter * 3);
 				var wallUv = new List<Vector2>(_counter * 2);
-				Vector3 norm = Mapbox.Unity.Constants.Math.Vector3Zero;
+				Vector3 norm = Constants.Math.Vector3Zero;
 
 				md.Vertices.Capacity = md.Vertices.Count + _counter * 2;
 				md.Normals.Capacity = md.Normals.Count + _counter * 2;


### PR DESCRIPTION
I realized height modifier wasn't utilizing submesh bool, which was set to false by default, and not creating second material field for objects. 
also material modifier wasn't instantiating materials while assignment for satellite imagery, which means textures was overriden to one material causing all tiles to have same satellite imagery.

this commit
-changes height modifier serialized field and default to true. (all example height modifiers changed to have it true if they are generating side walls).
-changes material modifier to instantiate materials if satellite imagery is applied

to test;
-select any scene you want
-set uv modifier to use satellite imagery
-set height modifier to create side walls as submesh
-set material modifier to use satellite imagery
-run and observe imagery on roofs correct

(it definitely doesn't take all these steps but for now this is the way)