### PR TITLE
Removing duplicate definitions of DescriptionAttribute

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatchingParameters.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatchingParameters.cs
@@ -5,20 +5,10 @@
 //-----------------------------------------------------------------------
 using System;
 using System.ComponentModel;
+using Mapbox.VectorTile.Geometry;
 
 namespace Mapbox.MapMatching
 {
-#if PORTABLE || WINDOWS_UWP
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-	public class DescriptionAttribute : Attribute {
-		private readonly string description;
-		public string Description { get { return description; } }
-		public DescriptionAttribute(string description) {
-			this.description = description;
-		}
-	}
-#endif
-
 	/// <summary>Directions profile id</summary>
 	public enum Profile
 	{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxTokenApi.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxTokenApi.cs
@@ -7,17 +7,7 @@ namespace Mapbox.Tokens
 	using Mapbox.Platform;
 	using System;
 	using System.ComponentModel;
-
-#if PORTABLE || WINDOWS_UWP
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-	public class DescriptionAttribute : Attribute {
-		private readonly string description;
-		public string Description { get { return description; } }
-		public DescriptionAttribute(string description) {
-			this.description = description;
-		}
-	}
-#endif
+	using Mapbox.VectorTile.Geometry;
 
 	public enum MapboxTokenStatus
 	{


### PR DESCRIPTION
Replaced the duplicate definitions of DescriptionAtrribute with the correct namespace as per @BergWerkGIS recommendation. 

@BergWerkGIS Could you test this on UWP build please?
___
_As part of the process of submitting this PR, please:_
- [ ] Document the PR changes
- [ ] Update the changelog
