### PR TITLE
Conversion helper methods

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/CameraBoundsTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/CameraBoundsTileProvider.cs
@@ -57,7 +57,7 @@ namespace Mapbox.Unity.Map
 				_ray = _camera.ViewportPointToRay(_viewportTarget);
 				if (_groundPlane.Raycast(_ray, out _hitDistance))
 				{
-					_currentLatitudeLongitude = transform.InverseTransformPoint(_ray.GetPoint(_hitDistance)).GetGeoPosition(_map.CenterMercator, _map.WorldRelativeScale);
+					_currentLatitudeLongitude = _map.WorldToGeoPosition(_ray.GetPoint(_hitDistance));
 					_currentTile = TileCover.CoordinateToTileId(_currentLatitudeLongitude, _map.AbsoluteZoom);
 
 					if (!_currentTile.Equals(_cachedTile))

--- a/sdkproject/Assets/Mapbox/Unity/Map/IMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/IMap.cs
@@ -28,6 +28,8 @@
 		Transform Root { get; }
 		float UnityTileSize { get; }
 		event Action OnInitialized;
+		Vector2d WorldToGeoPosition(Vector3 realworldPoint);
+		Vector3 GeoToWorldPosition(Vector2d latitudeLongitude);
 	}
 
 	public interface IMapWritable


### PR DESCRIPTION
Adds WorldToGeoPosition & GeoToWorldPosition to IMapReadable interface.

Changes the method call in `CameraBoundsTileProvider.cs` to use WorldToGeoPosition instead of generic call. This is related to recent PR #481 




___
_As part of the process of submitting this PR, please:_
- [x] Document the PR changes
- [ ] Update the changelog
