### PR TITLE
TileJSON API wrapper

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON.meta
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b68f3c7ef59bf3246a91043a1d382926
+folderAsset: yes
+timeCreated: 1515589539
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSON.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSON.cs
@@ -1,0 +1,50 @@
+﻿using Mapbox.Json;
+using Mapbox.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mapbox.Platform.TilesetTileJSON
+{
+	public class TileJSON
+	{
+
+		private IFileSource _fileSource;
+		private int _timeout;
+
+
+		public IFileSource FileSource { get { return _fileSource; } }
+
+
+		public TileJSON(IFileSource fileSource, int timeout)
+		{
+			_fileSource = fileSource;
+			_timeout = timeout;
+		}
+
+
+		public IAsyncRequest Get(string tilesetName, Action<TileJSONResponse> callback)
+		{
+			string url = string.Format(
+				"{0}v4/{1}.json?secure"
+				, Constants.BaseAPI
+				, tilesetName
+			);
+
+			return _fileSource.Request(
+				url
+				, (Response response) =>
+				{
+					string json = Encoding.UTF8.GetString(response.Data);
+					TileJSONResponse tileJSONResponse = JsonConvert.DeserializeObject<TileJSONResponse>(json);
+					callback(tileJSONResponse);
+				}
+				, _timeout
+			);
+		}
+
+
+
+
+	}
+}

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSON.cs.meta
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSON.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: ab78da4f6b501ed4b8ea92121d3392b8
+timeCreated: 1515589539
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONObjectVectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONObjectVectorLayer.cs
@@ -1,0 +1,32 @@
+﻿namespace Mapbox.Platform.TilesetTileJSON
+{
+	using Mapbox.Json;
+	using System.Collections.Generic;
+
+
+
+	public class TileJSONObjectVectorLayer
+	{
+
+		[JsonProperty("description")]
+		public string Description { get; set; }
+
+
+		[JsonProperty("fields")]
+		public Dictionary<string, string> Fields { get; set; }
+
+
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
+
+		[JsonProperty("source")]
+		public string Source { get; set; }
+
+
+		[JsonProperty("source_name")]
+		public string SourceName { get; set; }
+
+
+	}
+}

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONObjectVectorLayer.cs.meta
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONObjectVectorLayer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 4d926842f7750b041be895c39e959799
+timeCreated: 1515590225
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONReponse.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONReponse.cs
@@ -1,0 +1,165 @@
+﻿namespace Mapbox.Platform.TilesetTileJSON
+{
+
+	using Mapbox.Json;
+	using Mapbox.Utils;
+	using System;
+
+	public class TileJSONResponse
+	{
+
+
+		[JsonProperty("attribution")]
+		public string Attribution { get; set; }
+
+
+		[JsonProperty("autoscale")]
+		public bool AutoScale { get; set; }
+
+
+		private double[] _bounds;
+		[JsonProperty("bounds")]
+		public double[] Bounds
+		{
+			get { return _bounds; }
+			set
+			{
+				_bounds = value;
+				BoundsParsed = new Vector2dBounds(
+					new Vector2d(Bounds[1], Bounds[0])
+					, new Vector2d(Bounds[3], Bounds[2])
+				);
+			}
+		}
+
+
+		[JsonIgnore]
+		public Vector2dBounds BoundsParsed { get; private set; }
+
+
+		private double[] _center;
+		[JsonProperty("center")]
+		public double[] Center
+		{
+			get { return _center; }
+			set
+			{
+				_center = value;
+				CenterParsed = new Vector2d(_center[1], _center[0]);
+			}
+		}
+
+		[JsonIgnore]
+		public Vector2d CenterParsed { get; private set; }
+
+
+		private long? _created;
+		/// <summary>Concatenated tilesets don't have a created property </summary>
+		[JsonProperty("created")]
+		public long? Created
+		{
+			get { return _created; }
+			set
+			{
+				_created = value;
+				if (_created.HasValue)
+				{
+					CreatedUtc = UnixTimestampUtils.From(_created.Value);
+				}
+				else
+				{
+					CreatedUtc = null;
+				}
+			}
+		}
+
+
+		/// <summary>Concatenated tilesets don't have a created property </summary>
+		[JsonIgnore]
+		public DateTime? CreatedUtc { get; private set; }
+
+
+		[JsonProperty("description")]
+		public string Description { get; set; }
+
+
+		/// <summary>Can be empty</summary>
+		[JsonProperty("format")]
+		public string Format { get; set; }
+
+
+		/// <summary>Can be empty (for concatenated tilesets)</summary>
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
+
+		[JsonProperty("maxzoom")]
+		public int MaxZoom { get; set; }
+
+
+		[JsonProperty("minzoom")]
+		public int MinZoom { get; set; }
+
+
+		private long? _modified;
+		/// <summary>Unmodified tilesets don't have a modfied property </summary>
+		[JsonProperty("modified")]
+		public long? Modified
+		{
+			get { return _modified; }
+			set
+			{
+				_modified = value;
+				if (_modified.HasValue)
+				{
+					ModifiedUtc = UnixTimestampUtils.From(_modified.Value);
+				}
+				else
+				{
+					ModifiedUtc = null;
+				}
+			}
+		}
+
+
+		/// <summary>Unmodified tilesets don't have a modfied property </summary>
+		[JsonIgnore]
+		public DateTime? ModifiedUtc { get; private set; }
+
+
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+
+		[JsonProperty("private")]
+		public bool Private { get; set; }
+
+
+		[JsonProperty("scheme")]
+		public string Scheme { get; set; }
+
+
+		/// <summary>Can be empty</summary>
+		[JsonProperty("source")]
+		public string Source { get; set; }
+
+
+		[JsonProperty("tilejson")]
+		public string TileJSONVersion { get; set; }
+
+
+		[JsonProperty("tiles")]
+		public string[] Tiles { get; set; }
+
+
+		[JsonProperty("vector_layers")]
+		public TileJSONObjectVectorLayer[] VectorLayers { get; set; }
+
+
+		/// <summary>Can be empty (for concatenated tilesets)</summary>
+		[JsonProperty("webpage")]
+		public string WebPage { get; set; }
+
+
+	}
+}

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONReponse.cs.meta
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/TileJSON/TileJSONReponse.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8f58425aa7b211946a73691da0414edb
+timeCreated: 1515589539
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/TileJSONTest.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/TileJSONTest.cs
@@ -1,0 +1,227 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="FileSourceTest.cs" company="Mapbox">
+//     Copyright (c) 2016 Mapbox. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+// TODO: figure out how run tests outside of Unity with .NET framework, something like '#if !UNITY'
+#if UNITY_EDITOR
+#if UNITY_5_6_OR_NEWER
+
+namespace Mapbox.MapboxSdkCs.UnitTest
+{
+
+
+	using Mapbox.Platform;
+	using NUnit.Framework;
+	using UnityEngine.TestTools;
+	using System.Collections;
+	using Mapbox.Platform.TilesetTileJSON;
+
+
+	[TestFixture]
+	internal class TileJSONTest
+	{
+
+
+
+		[UnityTest]
+		public IEnumerator MapboxStreets()
+		{
+			string id = "mapbox.mapbox-streets-v7";
+			int minZoom = 0;
+			int maxZoom = 16;
+
+			TileJSONResponse response = null;
+
+			Unity.MapboxAccess.Instance.TileJSON.Get(
+				id
+				, (TileJSONResponse tjr) =>
+				{
+					response = tjr;
+				}
+			);
+
+
+			IEnumerator enumerator = ((FileSource)Unity.MapboxAccess.Instance.TileJSON.FileSource).WaitForAllRequests();
+			while (enumerator.MoveNext()) { yield return null; }
+
+			testsCommonToVectorAndRasterTilesets(response, id, minZoom, maxZoom);
+			testsForVectorTilesets(response);
+		}
+
+
+		[UnityTest]
+		public IEnumerator ConcatenatedVectorTilesets()
+		{
+			string id = "mapbox.mapbox-traffic-v1,mapbox.mapbox-streets-v7";
+			int minZoom = 0;
+			int maxZoom = 16;
+
+			TileJSONResponse response = null;
+
+			Unity.MapboxAccess.Instance.TileJSON.Get(
+				id
+				, (TileJSONResponse tjr) =>
+				{
+					response = tjr;
+				}
+			);
+
+
+			IEnumerator enumerator = ((FileSource)Unity.MapboxAccess.Instance.TileJSON.FileSource).WaitForAllRequests();
+			while (enumerator.MoveNext()) { yield return null; }
+
+			testsCommonToVectorAndRasterTilesets(
+				response
+				, id
+				, minZoom
+				, maxZoom
+				, boundsSouth: -90
+				, boundsNorth: 90
+			);
+			testsForVectorTilesets(response);
+		}
+
+
+		[UnityTest]
+		public IEnumerator MapboxSatellite()
+		{
+			string id = "mapbox.satellite";
+			int minZoom = 0;
+			int maxZoom = 22;
+
+			TileJSONResponse response = null;
+
+			Unity.MapboxAccess.Instance.TileJSON.Get(
+				id
+				, (TileJSONResponse tjr) =>
+				{
+					response = tjr;
+				}
+			);
+
+
+			IEnumerator enumerator = ((FileSource)Unity.MapboxAccess.Instance.TileJSON.FileSource).WaitForAllRequests();
+			while (enumerator.MoveNext()) { yield return null; }
+
+			testsCommonToVectorAndRasterTilesets(response, id, minZoom, maxZoom, boundsSouth: -85, boundsNorth: 85);
+		}
+
+
+		[UnityTest]
+		public IEnumerator MapboxEmerald()
+		{
+			string id = "mapbox.emerald";
+			int minZoom = 0;
+			int maxZoom = 22;
+
+			TileJSONResponse response = null;
+
+			Unity.MapboxAccess.Instance.TileJSON.Get(
+				id
+				, (TileJSONResponse tjr) =>
+				{
+					response = tjr;
+				}
+			);
+
+
+			IEnumerator enumerator = ((FileSource)Unity.MapboxAccess.Instance.TileJSON.FileSource).WaitForAllRequests();
+			while (enumerator.MoveNext()) { yield return null; }
+
+			testsCommonToVectorAndRasterTilesets(response, id, minZoom, maxZoom);
+
+			Assert.IsNotEmpty(response.Source, "'Source' not set properly");
+		}
+
+
+
+		private void testsForVectorTilesets(TileJSONResponse response)
+		{
+			Assert.IsNotNull(response.VectorLayers, "'VectorLayers' not set properly");
+			Assert.GreaterOrEqual(response.VectorLayers.Length, 1, "Not enough 'VectorLayers'");
+
+			TileJSONObjectVectorLayer vl1 = response.VectorLayers[0];
+			Assert.IsNotNull(vl1.Fields, "VectorLayer fields not parsed properly");
+			Assert.GreaterOrEqual(vl1.Fields.Count, 1, "Not enough vector layer fields");
+			Assert.IsNotEmpty(vl1.Id, "'Id' of vector layer not parsed properly");
+			Assert.IsNotEmpty(vl1.Source, "'Source' of vector layer not parsed properly");
+			Assert.IsNotEmpty(vl1.SourceName, "'SourceName' of vector layer not parsed properly");
+		}
+
+
+		private void testsCommonToVectorAndRasterTilesets(
+			TileJSONResponse response
+			, string id
+			, int minZoom
+			, int maxZoom
+			, double boundsWest = -180
+			, double boundsSouth = -85.0511
+			, double boundsEast = 180
+			, double boundsNorth = 85.0511
+		)
+		{
+			Assert.IsNotNull(response, "Parsing error or no data received from the servers.");
+
+			Assert.IsNotEmpty(response.Attribution, "Attribution not set.");
+
+			Assert.AreEqual(boundsWest, response.BoundsParsed.West, "Bounds.West does not match");
+			Assert.AreEqual(boundsSouth, response.BoundsParsed.South, 0.003, "Bounds.South does not match");
+			Assert.AreEqual(boundsEast, response.BoundsParsed.East, "Bounds.East does not match");
+			Assert.AreEqual(boundsNorth, response.BoundsParsed.North, 0.003, "Bounds.North does not match");
+
+			// this does not work as some tilesets report whole world bounds despite covering a small area only
+			// revisit some time in the future
+			//Assert.AreEqual(response.BoundsParsed.Center.x, response.CenterParsed.x, 0.003, "Center.x does not match");
+			//Assert.AreEqual(response.BoundsParsed.Center.y, response.CenterParsed.y, "Center.y does not match");
+
+			//concatenated tilesets don't have created property
+			if (response.Created.HasValue)
+			{
+				Assert.Greater(response.Created.Value, 0, "'Created' not set");
+				Assert.IsNotNull(response.CreatedUtc, "'CreatedUtc' not set properly'");
+			}
+
+			// mapbox.satellite doesn't set 'format': bug??
+			// revisit in the future
+			//Assert.IsNotEmpty(response.Format, "'Format' is empty");
+
+			// concatenated tilesets don't report 'id'
+			if (!id.Contains(","))
+			{
+				Assert.IsNotEmpty(response.Id, "'Id' is empty");
+				Assert.AreEqual(id, response.Id, "'Id' not set properly");
+			}
+			Assert.AreEqual(minZoom, response.MinZoom, "'MinZoom' not set properly");
+			Assert.AreEqual(maxZoom, response.MaxZoom, "'MaxZoom' not set properly");
+
+			//Unmodified tilesets don't have a modified property
+			if (response.Modified.HasValue)
+			{
+				Assert.Greater(response.Modified.Value, 0, "'Modified not set'");
+				Assert.IsTrue(response.ModifiedUtc.HasValue, "'Modified not properly parsed'");
+			}
+
+			Assert.IsNotEmpty(response.Name, "'Name' not set properly");
+			Assert.IsFalse(response.Private, "'Private' not set properly");
+			Assert.AreEqual("xyz", response.Scheme, "'Scheme' not set properly");
+			Assert.IsNotEmpty(response.TileJSONVersion, "'TileJSONVersion not set properly");
+
+			Assert.IsNotNull(response.Tiles, "'Tiles' not set properly");
+			Assert.GreaterOrEqual(response.Tiles.Length, 1, "Not enough 'Tiles'");
+
+			// concatenated tilesets don't report 'webpage'
+			if (!id.Contains(","))
+			{
+				Assert.IsNotEmpty(response.WebPage, "'WebPage' not set properly");
+			}
+		}
+
+
+
+	}
+}
+
+#endif
+#endif

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/TileJSONTest.cs.meta
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/TileJSONTest.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 609e55c6e2c34624eb02d61d96cb34f0
+timeCreated: 1515592137
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Utils/UnixTimestampUtils.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Utils/UnixTimestampUtils.cs
@@ -29,7 +29,7 @@ namespace Mapbox.Utils {
 
 
 		/// <summary>
-		/// Convert from Unitx timestamp to DateTime
+		/// Convert from Unitx timestamp to DateTime. Uses TimeSpan.FromSeconds to caluclate offset since epoch 0
 		/// </summary>
 		/// <param name="timestamp"></param>
 		/// <returns></returns>
@@ -38,6 +38,16 @@ namespace Mapbox.Utils {
 			return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Add(TimeSpan.FromSeconds(timestamp));
 		}
 
+		/// <summary>
+		/// Convert from Unitx timestamp to DateTime. Uses TimeSpan.FromTicks to caluclate offset since epoch 0
+		/// </summary>
+		/// <param name="timestamp"></param>
+		/// <returns></returns>
+		public static DateTime From(long timestamp)
+		{
+			//return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Add(TimeSpan.FromSeconds(timestamp)).ToLocalTime();
+			return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Add(TimeSpan.FromTicks(timestamp));
+		}
 
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -11,6 +11,7 @@ namespace Mapbox.Unity
 	using Mapbox.Map;
 	using Mapbox.MapMatching;
 	using Mapbox.Tokens;
+	using Mapbox.Platform.TilesetTileJSON;
 
 	/// <summary>
 	/// Object for retrieving an API token and making http requests.
@@ -236,6 +237,23 @@ namespace Mapbox.Unity
 					_tokenValidator = new MapboxTokenApi();
 				}
 				return _tokenValidator;
+			}
+		}
+
+
+		TileJSON _tileJson;
+		/// <summary>
+		/// Lazy TileJSON wrapper: https://www.mapbox.com/api-documentation/#retrieve-tilejson-metadata
+		/// </summary>
+		public TileJSON TileJSON
+		{
+			get
+			{
+				if (_tileJson == null)
+				{
+					_tileJson = new TileJSON(new FileSource(_configuration.AccessToken), _configuration.DefaultTimeout);
+				}
+				return _tileJson;
 			}
 		}
 


### PR DESCRIPTION
Wrapper around the TileJSON API for querying metadata about tilesets:
https://www.mapbox.com/api-documentation/#retrieve-tilejson-metadata

Includes tests 🎉 
![image](https://user-images.githubusercontent.com/4549888/34825723-ec822dfa-f6d3-11e7-8d4d-05d381e39607.png)

Usage:
```c#
using Mapbox.Platform.TilesetTileJSON;

MapboxAccess.Instance.TileJSON.Get(
    "mapbox.mapbox-streets-v7"
    , (TileJSONResponse response) =>
    {
        // do something with 'response';
    }
);
```