### PR TITLE
Layer Visualizer for Building Ids

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/VectorFeatureUnity.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/VectorFeatureUnity.cs
@@ -31,15 +31,15 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			Points.Clear();
 
 			//this is a temp hack until we figure out how streets ids works
-			if (feature.Id > 10000)
+			if (feature.Id > 10000) //ids from building dataset is big ulongs 
 			{
 				Id = feature.Id.ToString();
-				_geom = feature.Geometry<float>();
+				_geom = feature.Geometry<float>(); //and we're not clipping by passing no parameters
 			}
-			else
+			else //streets ids, will require clipping
 			{
 				Id = string.Empty;
-				_geom = feature.Geometry<float>(0);
+				_geom = feature.Geometry<float>(0); //passing zero means clip at tile edge
 			}
 
 			_rectSizex = tile.Rect.Size.x;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/VectorFeatureUnity.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/VectorFeatureUnity.cs
@@ -7,6 +7,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 
 	public class VectorFeatureUnity
 	{
+		public string Id;
 		public VectorTileFeature Data;
 		public Dictionary<string, object> Properties;
 		public List<List<Vector3>> Points = new List<List<Vector3>>();
@@ -29,10 +30,21 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			Properties = Data.GetProperties();
 			Points.Clear();
 
+			//this is a temp hack until we figure out how streets ids works
+			if (feature.Id > 10000)
+			{
+				Id = feature.Id.ToString();
+				_geom = feature.Geometry<float>();
+			}
+			else
+			{
+				Id = string.Empty;
+				_geom = feature.Geometry<float>(0);
+			}
+
 			_rectSizex = tile.Rect.Size.x;
 			_rectSizey = tile.Rect.Size.y;
-
-			_geom = feature.Geometry<float>(0);
+						
 			_geomCount = _geom.Count;
 			for (int i = 0; i < _geomCount; i++)
 			{


### PR DESCRIPTION
change VectorFeatureUnity and VectorLayerVisualizer classes to support buildings ids and do not render duplicates of same featuer from different tiles









___
_As part of the process of submitting this PR, please:_
- [ ] Document the PR changes
- [ ] Update the changelog
