### PR TITLE
Add EditorConfig to enforce coding style

### DIFF
--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -1,3 +1,5 @@
+- Use an IDE that respects `.editorconfig` file (http://editorconfig.org/#download) and you won't have to worry about most of the stuff below :smirk:
+
 - Use tabs, not spaces, for indentation.
 
 - Private fields should be prefixed with an underscore (`_privateField`) and generally avoid `this` keyword.

--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,5 +1,11 @@
 ﻿## CHANGELOG
 
+### v.?.?.?
+*TBD*
+
+#####
+- Included EditorConfig file to enforce coding style
+
 ### v.1.3.0
 *12/18/2017*
 

--- a/sdkproject/Assets/Mapbox/.editorconfig
+++ b/sdkproject/Assets/Mapbox/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*.cs]
 indent_style = tab
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 # avoid "this." if not necessary
 dotnet_style_qualification_for_field = false:warning

--- a/sdkproject/Assets/Mapbox/.editorconfig
+++ b/sdkproject/Assets/Mapbox/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*.cs]
+indent_style = tab
+insert_final_newline = true
+
+# avoid "this." if not necessary
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true


### PR DESCRIPTION
Added an `.editorconfig` file to enforce our coding style https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md

About EditorConfig: http://editorconfig.org/

Reference of available settings:
https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference



___
_As part of the process of submitting this PR, please:_
- [ ] Document the PR changes
- [X] Update the changelog
