### PR TITLE
Zoomable map scaling fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeBasicMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeBasicMap.cs
@@ -12,8 +12,8 @@
 			// For quadtree implementation of the map, the map scale needs to be compensated for. 
 			var scaleFactor = Mathf.Pow(2, (InitialZoom - AbsoluteZoom));
 
-			var worldPos = Conversions.GeoToWorldPosition(latitudeLongitude, CenterMercator, WorldRelativeScale).ToVector3xz();
-			return _root.TransformPoint(worldPos) * scaleFactor;
+			var worldPos = Conversions.GeoToWorldPosition(latitudeLongitude, CenterMercator, WorldRelativeScale * scaleFactor).ToVector3xz();
+			return _root.TransformPoint(worldPos);
 		}
 
 		public override Vector2d WorldToGeoPosition(Vector3 realworldPoint)
@@ -21,7 +21,7 @@
 			// For quadtree implementation of the map, the map scale needs to be compensated for. 
 			var scaleFactor = Mathf.Pow(2, (InitialZoom - AbsoluteZoom));
 
-			return (_root.InverseTransformPoint(realworldPoint) / scaleFactor).GetGeoPosition(CenterMercator, WorldRelativeScale);
+			return (_root.InverseTransformPoint(realworldPoint)).GetGeoPosition(CenterMercator, WorldRelativeScale / scaleFactor);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeBasicMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeBasicMap.cs
@@ -21,7 +21,7 @@
 			// For quadtree implementation of the map, the map scale needs to be compensated for. 
 			var scaleFactor = Mathf.Pow(2, (InitialZoom - AbsoluteZoom));
 
-			return (_root.InverseTransformPoint(realworldPoint)).GetGeoPosition(CenterMercator, WorldRelativeScale / scaleFactor);
+			return (_root.InverseTransformPoint(realworldPoint)).GetGeoPosition(CenterMercator, WorldRelativeScale * scaleFactor);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeTileProvider.cs
@@ -104,15 +104,15 @@
 
 		void Update()
 		{
-			//Camera Debugging
-			Vector3[] frustumCorners = new Vector3[4];
-			_camera.CalculateFrustumCorners(new Rect(0, 0, 1, 1), _camera.transform.position.y, Camera.MonoOrStereoscopicEye.Mono, frustumCorners);
+			////Camera Debugging
+			//Vector3[] frustumCorners = new Vector3[4];
+			//_camera.CalculateFrustumCorners(new Rect(0, 0, 1, 1), _camera.transform.position.y, Camera.MonoOrStereoscopicEye.Mono, frustumCorners);
 
-			for (int i = 0; i < 4; i++)
-			{
-				var worldSpaceCorner = _camera.transform.TransformVector(frustumCorners[i]);
-				Debug.DrawRay(_camera.transform.position, worldSpaceCorner, Color.blue);
-			}
+			//for (int i = 0; i < 4; i++)
+			//{
+			//	var worldSpaceCorner = _camera.transform.TransformVector(frustumCorners[i]);
+			//	Debug.DrawRay(_camera.transform.position, worldSpaceCorner, Color.blue);
+			//}
 
 			if (!_shouldUpdate)
 			{
@@ -150,31 +150,65 @@
 
 		private Vector2dBounds getcurrentViewPortWebMerc(bool useGroundPlane = true)
 		{
-			Vector3 hitPntLL;
-			Vector3 hitPntUR;
+			Vector3[] hitPnt = new Vector3[4];
 
 			if (useGroundPlane)
 			{
 				// rays from camera to groundplane: lower left and upper right
-				Ray rayLL = _camera.ViewportPointToRay(new Vector3(0, 0));
-				Ray rayUR = _camera.ViewportPointToRay(new Vector3(1, 1));
-				hitPntLL = getGroundPlaneHitPoint(rayLL);
-				hitPntUR = getGroundPlaneHitPoint(rayUR);
+				Ray ray00 = _camera.ViewportPointToRay(new Vector3(0, 0));
+				Ray ray01 = _camera.ViewportPointToRay(new Vector3(0, 1));
+				Ray ray10 = _camera.ViewportPointToRay(new Vector3(1, 0));
+				Ray ray11 = _camera.ViewportPointToRay(new Vector3(1, 1));
+				hitPnt[0] = getGroundPlaneHitPoint(ray00);
+				hitPnt[1] = getGroundPlaneHitPoint(ray01);
+				hitPnt[2] = getGroundPlaneHitPoint(ray10);
+				hitPnt[3] = getGroundPlaneHitPoint(ray11);
 			}
-			else
+
+			// Find min max bounding box. 
+			// TODO : Find a better way of doing this. 
+			float minX = float.MaxValue;
+			float minZ = float.MaxValue;
+			float maxX = float.MinValue;
+			float maxZ = float.MinValue;
+			for (int i = 0; i < 4; i++)
 			{
-				hitPntLL = _camera.ViewportToWorldPoint(new Vector3(0, 0, _camera.transform.localPosition.y));
-				hitPntUR = _camera.ViewportToWorldPoint(new Vector3(1, 1, _camera.transform.localPosition.y));
+				if (minX > hitPnt[i].x)
+				{
+					minX = hitPnt[i].x;
+				}
+
+				if (minZ > hitPnt[i].z)
+				{
+					minZ = hitPnt[i].z;
+				}
+
+				if (maxX < hitPnt[i].x)
+				{
+					maxX = hitPnt[i].x;
+				}
+
+				if (maxZ < hitPnt[i].z)
+				{
+					maxZ = hitPnt[i].z;
+				}
 			}
+
+			Vector3 hitPntLL = new Vector3(minX, 0, minZ);
+			Vector3 hitPntUR = new Vector3(maxX, 0, maxZ);
+
+			//Debug.Log(hitPntLL + " - " + hitPntUR);
 
 			var llLatLong = _map.WorldToGeoPosition(hitPntLL);
 			var urLatLong = _map.WorldToGeoPosition(hitPntUR);
 
 			Vector2dBounds tileBounds = new Vector2dBounds(Conversions.LatLonToMeters(llLatLong), Conversions.LatLonToMeters(urLatLong));
+
+			// Bounds debugging. 
+			Debug.DrawLine(_camera.transform.position, hitPntLL, Color.blue);
+			Debug.DrawLine(_camera.transform.position, hitPntUR, Color.red);
 			return tileBounds;
 		}
-
-
 		private Vector3 getGroundPlaneHitPoint(Ray ray)
 		{
 			float distance;

--- a/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/QuadTreeTileProvider.cs
@@ -167,25 +167,11 @@
 				hitPntUR = _camera.ViewportToWorldPoint(new Vector3(1, 1, _camera.transform.localPosition.y));
 			}
 
-			//get tile scale at equator, otherwise calucations don't work at higher latitudes
-			double factor = Conversions.GetTileScaleInMeters(0, _map.AbsoluteZoom) * 256 / _map.UnityTileSize;
-			//convert Unity units to WebMercator and LatLng to get real world bounding box
-			double llx = _map.CenterMercator.x + hitPntLL.x * factor;
-			double lly = _map.CenterMercator.y + hitPntLL.z * factor;
-			double urx = _map.CenterMercator.x + hitPntUR.x * factor;
-			double ury = _map.CenterMercator.y + hitPntUR.z * factor;
-			llx = llx > 0 ? Mathd.Min(llx, Mapbox.Utils.Constants.WebMercMax) : Mathd.Max(llx, -Mapbox.Utils.Constants.WebMercMax);
-			lly = lly > 0 ? Mathd.Min(lly, Mapbox.Utils.Constants.WebMercMax) : Mathd.Max(lly, -Mapbox.Utils.Constants.WebMercMax);
-			urx = urx > 0 ? Mathd.Min(urx, Mapbox.Utils.Constants.WebMercMax) : Mathd.Max(urx, -Mapbox.Utils.Constants.WebMercMax);
-			ury = ury > 0 ? Mathd.Min(ury, Mapbox.Utils.Constants.WebMercMax) : Mathd.Max(ury, -Mapbox.Utils.Constants.WebMercMax);
-			Vector2d llWebMerc = new Vector2d(llx, lly);
-			Vector2d urWebMerc = new Vector2d(urx, ury);
+			var llLatLong = _map.WorldToGeoPosition(hitPntLL);
+			var urLatLong = _map.WorldToGeoPosition(hitPntUR);
 
-
-			return new Vector2dBounds(
-				llWebMerc
-				, urWebMerc
-			);
+			Vector2dBounds tileBounds = new Vector2dBounds(Conversions.LatLonToMeters(llLatLong), Conversions.LatLonToMeters(urLatLong));
+			return tileBounds;
 		}
 
 


### PR DESCRIPTION
Fixes scaling issue which was causing the map bounds to get drifted as the camera was physically moved. 
Fixes #511 , map bounds were incorrect when camera is rotated. 

use the following script to test scaling fix. In zoomable map example, attach script to the camera and disable the QuadtreeCameraMovement script. 
```
namespace Mapbox.Examples
{
	using Mapbox.Unity.Map;
	using UnityEngine;
	using UnityEngine.EventSystems;

	public class MoveCamera : MonoBehaviour
	{
		[SerializeField]
		float _panSpeed = 20f;

		[SerializeField]
		float _zoomSpeed = 0.00000001f;

		[SerializeField]
		Camera _referenceCamera;

		[SerializeField]
		QuadTreeTileProvider _quadTreeTileProvider;

		[SerializeField]
		AbstractMap _dynamicZoomMap;

		Quaternion _originalRotation;
		Vector3 _origin;
		Vector3 _delta;
		bool _shouldDrag;

		void HandleTouch()
		{
			float zoomFactor = 0.0f;
			//pinch to zoom. 
			switch (Input.touchCount)
			{
				case 1:
					{
						HandleMouseAndKeyBoard();
					}
					break;
				case 2:
					{
						// Store both touches.
						Touch touchZero = Input.GetTouch(0);
						Touch touchOne = Input.GetTouch(1);

						// Find the position in the previous frame of each touch.
						Vector2 touchZeroPrevPos = touchZero.position - touchZero.deltaPosition;
						Vector2 touchOnePrevPos = touchOne.position - touchOne.deltaPosition;

						// Find the magnitude of the vector (the distance) between the touches in each frame.
						float prevTouchDeltaMag = (touchZeroPrevPos - touchOnePrevPos).magnitude;
						float touchDeltaMag = (touchZero.position - touchOne.position).magnitude;

						// Find the difference in the distances between each frame.
						zoomFactor = 0.05f * (touchDeltaMag - prevTouchDeltaMag);
					}
					ZoomMapUsingTouchOrMouse(zoomFactor);
					break;
				default:
					break;
			}
		}

		void ZoomMapUsingTouchOrMouse(float zoomFactor)
		{
			_quadTreeTileProvider.UpdateMapProperties(_dynamicZoomMap.CenterLatitudeLongitude, Mathf.Max(0.0f, Mathf.Min(_dynamicZoomMap.Zoom + zoomFactor * _zoomSpeed, 21.0f)));
		}

		void HandleMouseAndKeyBoard()
		{
			var x = 0f;
			var y = 0f;
			var z = 0f;

			if (Input.GetMouseButton(0) && !EventSystem.current.IsPointerOverGameObject())
			{
				var mousePosition = Input.mousePosition;
				mousePosition.z = _referenceCamera.transform.localPosition.y;
				_delta = _referenceCamera.ScreenToWorldPoint(mousePosition) - _referenceCamera.transform.localPosition;
				_delta.y = 0f;
				if (_shouldDrag == false)
				{
					_shouldDrag = true;
					_origin = _referenceCamera.ScreenToWorldPoint(mousePosition);
				}
			}
			else
			{
				_shouldDrag = false;
			}

			if (_shouldDrag == true)
			{
				var offset = _origin - _delta;
				offset.y = transform.localPosition.y;
				transform.localPosition = offset;
			}
			else
			{
				if (EventSystem.current.IsPointerOverGameObject())
				{
					return;
				}

				// TODO: disable keyboard-specific input.
				// zoom
				float scrollDelta = 0.0f;
				scrollDelta = Input.GetAxis("Mouse ScrollWheel");
				ZoomMapUsingTouchOrMouse(scrollDelta);
			}
		}

		void Awake()
		{
			_originalRotation = Quaternion.Euler(0, transform.eulerAngles.y, 0);

			if (_referenceCamera == null)
			{
				_referenceCamera = GetComponent<Camera>();
				if (_referenceCamera == null)
				{
					throw new System.Exception("You must have a reference camera assigned!");
				}
			}
		}

		void LateUpdate()
		{

			if (Input.touchSupported && Input.touchCount > 0)
			{
				HandleTouch();
			}
			else
			{
				HandleMouseAndKeyBoard();
			}
		}
	}
}
```


___
_As part of the process of submitting this PR, please:_
- [ ] Document the PR changes
- [ ] Update the changelog
