### PR TITLE
add QueryTerrainHeight function to AbstractMap

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -233,6 +233,15 @@ namespace Mapbox.Unity.Map
 			return _root.TransformPoint(Conversions.GeoToWorldPosition(latitudeLongitude, CenterMercator, WorldRelativeScale).ToVector3xz());
 		}
 
+		public virtual float QueryHeightData(Vector2d latlong)
+		{
+			var _meters = Conversions.LatLonToMeters(latlong.x, latlong.y);
+			var tile = MapVisualizer.ActiveTiles[Conversions.LatitudeLongitudeToTileId(latlong.x, latlong.y, (int)Zoom)];
+			var _rect = tile.Rect;
+			var _worldPos = GeoToWorldPosition(new Vector2d(latlong.x, latlong.y));
+			return tile.QueryHeightData((float)((_meters - _rect.Min).x / _rect.Size.x), (float)((_meters.y - _rect.Max.y) / _rect.Size.y));
+		}
+
 		public abstract void Initialize(Vector2d latLon, int zoom);
 
 		public void Reset()


### PR DESCRIPTION
**Related issue**

**Description of changes**

Adds an API call to query height at a certain Latitude longitude. 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

cc @brnkhy pulling this branch as a PR. 
