### PR TITLE
Fix compile error related to return type.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Utilities/Conversions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/Conversions.cs
@@ -200,13 +200,13 @@ namespace Mapbox.Unity.Utilities
 		/// <param name="longitude"> The longitude. </param>
 		/// <param name="zoom"> Zoom level. </param>
 		/// <returns> A <see cref="T:UnityEngine.Vector2d"/> xy tile ID. </returns>
-		public static Vector2d LatitudeLongitudeToTileId(double latitude, double longitude, int zoom)
+		public static UnwrappedTileId LatitudeLongitudeToTileId(double latitude, double longitude, int zoom)
 		{
 			var x = (int)Math.Floor((longitude + 180.0) / 360.0 * Math.Pow(2.0, zoom));
 			var y = (int)Math.Floor((1.0 - Math.Log(Math.Tan(latitude * Math.PI / 180.0)
 					+ 1.0 / Math.Cos(latitude * Math.PI / 180.0)) / Math.PI) / 2.0 * Math.Pow(2.0, zoom));
 
-			return new Vector2d(x, y);
+			return new UnwrappedTileId(x, y, zoom);
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Related issue**

Example: Fixes missing change from #571 

**Description of changes**

Return type of LatitudeLongitudeToTile id was wrong.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
