### PR TITLE
updated Clip/Box shader

### DIFF
--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_BuildingsMaterial.mat
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_BuildingsMaterial.mat
@@ -43,7 +43,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 84c9cdf116e5247218ff6ef335b0ef67, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
@@ -66,9 +66,9 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Metallic: 0.304
+    - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
@@ -80,7 +80,7 @@ Material:
     m_Colors:
     - _BoxRotation: {r: -0, g: 0, b: 0, a: 0}
     - _BoxSize: {r: 0, g: 0, b: 0, a: 0}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0.71323526, g: 0.71323526, b: 0.71323526, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 0}
     - _Origin: {r: 0, g: 0, b: 0, a: 0}
     - _PlaneNormal: {r: 1.06, g: -44.85, b: 1, a: 1}

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_BuildingsMaterial_top.mat
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_BuildingsMaterial_top.mat
@@ -43,7 +43,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 84c9cdf116e5247218ff6ef335b0ef67, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
@@ -66,9 +66,9 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Metallic: 0.304
+    - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_TerrainMaterial.mat
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Materials/Clip_TerrainMaterial.mat
@@ -66,9 +66,9 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Metallic: 0.304
+    - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
@@ -25,16 +25,53 @@
 
 // clips any pixel in an area defined by size, rotation, and position
 
+
 Shader "Clip/Box"
 {
 	Properties
 	{
-        _Color("Color", Color) = (1,1,1,1)
+		_Color("Color", Color) = (1,1,1,1)
 		_MainTex("Main Texture", 2D) = "white" {}
 		_Glossiness("Smoothness", Range(0,1)) = 0.5
 		_Metallic("Metallic", Range(0,1)) = 0.0
 	}
-    
+
+	SubShader
+	{
+		Tags { "RenderType" = "Opaque" }
+		Cull Off
+		CGPROGRAM
+		// Physically based Standard lighting model, and enable shadows on all light types
+		#pragma surface surf Standard fullforwardshadows
+
+		// Use shader model 3.0 target, to get nicer looking lighting
+		#pragma target 3.0
+
+		struct Input
+		{
+			float2 uv_MainTex;
+			float2 uv_Conversion;
+			float2 uv_BumpMap;
+			float3 worldPos;
+		};
+
+		half _Glossiness;
+		half _Metallic;
+		half _ConvertDistance;
+		half _ConvertEmission;
+
+		float3 _Origin;
+		float3 _BoxSize;
+		float3 _BoxRotation;Shader "Clip/Box"
+{
+	Properties
+	{
+		_Color("Color", Color) = (1,1,1,1)
+		_MainTex("Main Texture", 2D) = "white" {}
+		_Glossiness("Smoothness", Range(0,1)) = 0.5
+		_Metallic("Metallic", Range(0,1)) = 0.0
+	}
+
 	SubShader
 	{
 		Tags { "RenderType" = "Opaque" }
@@ -63,7 +100,7 @@ Shader "Clip/Box"
 		float3 _BoxSize;
 		float3 _BoxRotation;
 
-        fixed4 _Color;
+		fixed4 _Color;
 
 		sampler2D _MainTex;
 		sampler2D _BumpMap;
@@ -97,11 +134,11 @@ Shader "Clip/Box"
 			clip(-1 * t);
 			
 			fixed4 albedo = tex2D(_MainTex, IN.uv_MainTex);
-            
-            o.Albedo = albedo.rgb * _Color;
+
+			o.Albedo = albedo.rgb * _Color;
 			o.Metallic = _Metallic;
 			o.Smoothness = _Glossiness;
-            o.Alpha = albedo.a * _Color.a;
+			o.Alpha = albedo.a * _Color.a;
 
 		}
 			ENDCG

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
@@ -102,6 +102,7 @@ Shader "Clip/Box"
 			o.Metallic = _Metallic;
 			o.Smoothness = _Glossiness;
             o.Alpha = albedo.a * _Color.a;
+
 		}
 			ENDCG
 	}

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Shader/Clip_Box.shader
@@ -29,16 +29,12 @@ Shader "Clip/Box"
 {
 	Properties
 	{
-		_ConvertEmission("Convert Emission", Range(0,1)) = 0.5
-		_ConvertDistance("Conversion Distance", float) = 0.1
-		_Conversion("Conversion (RGB)", 2D) = "white" {}
-
+        _Color("Color", Color) = (1,1,1,1)
 		_MainTex("Main Texture", 2D) = "white" {}
-		_BumpMap("Bumpmap", 2D) = "bump" {}
 		_Glossiness("Smoothness", Range(0,1)) = 0.5
 		_Metallic("Metallic", Range(0,1)) = 0.0
-
 	}
+    
 	SubShader
 	{
 		Tags { "RenderType" = "Opaque" }
@@ -67,6 +63,8 @@ Shader "Clip/Box"
 		float3 _BoxSize;
 		float3 _BoxRotation;
 
+        fixed4 _Color;
+
 		sampler2D _MainTex;
 		sampler2D _BumpMap;
 		sampler2D _Conversion;
@@ -75,7 +73,6 @@ Shader "Clip/Box"
 		{
 			float3 dir = IN.worldPos - _Origin;
 			float3 rads = float3(radians(_BoxRotation.x), radians(_BoxRotation.y), radians(_BoxRotation.z));
-
 			// z
 			dir = cos(rads.z) * dir + sin(rads.z) * cross(float3(0,0,1.0f), dir) + (1.0f - cos(rads.z)) * dot(float3(0,0,1.0f), dir) * float3(0,0,1.0f);
 			// x
@@ -98,23 +95,13 @@ Shader "Clip/Box"
 			t = max(t, dist.z);
 			
 			clip(-1 * t);
-
-			float convert_mask = max(dist.x,max(dist.y, dist.z)) / _ConvertDistance;
-			convert_mask = clamp(convert_mask, 0, 1);
 			
 			fixed4 albedo = tex2D(_MainTex, IN.uv_MainTex);
-			albedo *= convert_mask;
-
-			fixed4 convert = tex2D(_Conversion, IN.uv_Conversion);
-			convert *= 1.0 - convert_mask;
-
-			o.Albedo = albedo.rgb + convert.rgb;
-			o.Emission = convert.rgb * _ConvertEmission;
-			o.Normal = UnpackNormal(tex2D(_BumpMap, IN.uv_BumpMap));
+            
+            o.Albedo = albedo.rgb * _Color;
 			o.Metallic = _Metallic;
 			o.Smoothness = _Glossiness;
-			o.Alpha = albedo.a + convert.a;
-
+            o.Alpha = albedo.a * _Color.a;
 		}
 			ENDCG
 	}


### PR DESCRIPTION
**Related issue**

[Relates to this ticket
](https://github.com/mapbox/unity/issues/498)

**Description of changes**

Updated Clip/Box shader to take in colors. Deleted conversion thingy with the extra texture. Removed bump mapping. AKA simplified shader.


**Reviewers**

Tag your reviewer(s). Choose wisely.
