### PR TITLE
Fix range height extrusion

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,14 +1,20 @@
 ﻿## CHANGELOG
+### v.1.4.0
+*??/??/2018*
+
+#####
+- Fix `Range Property` extrusion option for vector features.
+- Add scale factor for extrusion value derived from feature property.
 
 ### v.1.4.0
 *03/20/2018*
 
 #####
-- Drag and drop prefabs for most common use cases. 
+- Drag and drop prefabs for most common use cases.
 - New Abstract Map UI
-- Style development - colorization and atlas template generator 
+- Style development - colorization and atlas template generator
 - Use texture atlas for building geometries.
-- Merge buildings with unique ids using the experimental 3D buildings tileset. 
+- Merge buildings with unique ids using the experimental 3D buildings tileset.
 - Added a API call on AbstractMap to query height at a certain latitude longitude.
 - Included EditorConfig file to enforce coding style
 - Integration of previously seperate AR support https://github.com/mapbox/mapbox-unity-sdk/pull/544
@@ -16,7 +22,7 @@
 ### v.1.3.0
 *12/18/2017*
 
-##### Upgrade Instructions 
+##### Upgrade Instructions
 - As always, if you already have a project with a previous version of the SDK, please remove older versions before installing this new one!
 - `FeatureBehaviour` is no longer added to feature gameobjects by default. Use a `FeatureBehaviourModifier` to add this component (optimization).
 - `TextureModifier` is obsolete. Please use `MaterialModifier`.
@@ -31,7 +37,7 @@
 
 ##### New Features
 - Added convenience methods to `AbstractMap`  to convert between Lat/Lon ↔ Vector3. This also works for maps that have been translated, rotated, or scaled! #387
-- Added tile error exception events that you can hook into to know when specific tiles fail to load. We provide an example `TileErrorHandler` object that logs these to console. 
+- Added tile error exception events that you can hook into to know when specific tiles fail to load. We provide an example `TileErrorHandler` object that logs these to console.
 - Added C# wrapper for Mapbox Token API (to validate tokens).
 - Added transparency shader for raster tiles—this enables you to convert black to alpha from Mapbox studio styles (to render just road labels, for example).
 - Added new `LoftModifier`—use this to make complex geometry from line features.
@@ -43,7 +49,7 @@
 ##### Bug Fixes
 - It should now be safe to nest the Mapbox folder (SDK) in your own projects.
 - You can now properly change/load scenes at runtime. #381
-- Fixed token validation issues (validate token when initializing `MapboxAccess`). #430 
+- Fixed token validation issues (validate token when initializing `MapboxAccess`). #430
 - Custom inspectors now properly serialize assets assigned via built-in object browser.
 - Fix for certain tile providers not updating properly when re-initializing a map.
 - Fixed issue where clipped features would result in several new features. #398
@@ -67,7 +73,7 @@
   - Array support to mock a specific route (`LocationArrayEditorLocationProvider`).
   - Transform support on `EditorLocationProvider` to create simple offsets.
   - Use Unity Remote app to send location updates directly to the Unity editor from your device!
-- `DynamicZoom` example has been improved, see new `Zoomable` map example. 
+- `DynamicZoom` example has been improved, see new `Zoomable` map example.
 - Added string to lat/lon conversion method.
 - Various nodes in the map factory framework now have public fields to support run-time styling or modification before map generation (based on settings, for example).
 - Maps now support float values for zoom level—you can use this to inform camera controllers, for example.
@@ -214,7 +220,7 @@
 - Elevation textures are no longer held in memory and height data parsing and access is much faster
 - Added new `FlatTerrainFactory` that is optimized specifically for flat maps
 - Tiles can now be cached in memory—configure the cache size in `MapboxAccess.cs` (default size is 500)
-- Slippy maps now dispose tiles that determined to be "out of range" 
+- Slippy maps now dispose tiles that determined to be "out of range"
   - Tiles that are out of range before completion are properly cancelled
 - Terrain generation in Unity 5.5+ should be much faster and allocate less memory
 
@@ -256,12 +262,12 @@
 - Fixed issue where visualizers for `MeshFactories` were not being serialized properly
 - Fixed null reference exception when creating a new `MeshFactory`
 
-### v0.5.0 
+### v0.5.0
 
 *04/26/2017*
 
-- Added support for UWP 
-    - Share your Hololens creations with us! 
+- Added support for UWP
+    - Share your Hololens creations with us!
 - Fixed precision issue with tile conversions
     - Replaced `Geocoordinate` with `Vector2d`
 - Mapbox API Token is now stored in MapboxAccess.txt

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/GeometryExtrusionOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/GeometryExtrusionOptions.cs
@@ -19,6 +19,7 @@
 		public string propertyName = "height";
 		public float minimumHeight = 0f;
 		public float maximumHeight = 0f;
+		public float extrusionScaleFactor = 1f;
 	}
 
 	[Serializable]
@@ -38,6 +39,7 @@
 		public string propertyName = "height";
 		public float minimumHeight = 0f;
 		public float maximumHeight = 0f;
+		public float extrusionScaleFactor = 1f;
 
 		public GeometryExtrusionWithAtlasOptions()
 		{
@@ -50,6 +52,7 @@
 			propertyName = extrusionOptions.propertyName;
 			minimumHeight = extrusionOptions.minimumHeight;
 			maximumHeight = extrusionOptions.maximumHeight;
+			extrusionScaleFactor = extrusionOptions.extrusionScaleFactor;
 
 			texturingType = uvOptions.texturingType;
 			atlasInfo = uvOptions.atlasInfo;

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/GeometryExtrusionOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/GeometryExtrusionOptions.cs
@@ -3,6 +3,7 @@
 	using System;
 	using Mapbox.Unity.MeshGeneration.Modifiers;
 	using Mapbox.Unity.MeshGeneration.Data;
+	using UnityEngine;
 
 	[Serializable]
 	public class GeometryExtrusionOptions : ModifierProperties
@@ -16,9 +17,11 @@
 		}
 		public ExtrusionType extrusionType = ExtrusionType.None;
 		public ExtrusionGeometryType extrusionGeometryType = ExtrusionGeometryType.RoofAndSide;
+		[Tooltip("Property name in feature layer to use for extrusion.")]
 		public string propertyName = "height";
 		public float minimumHeight = 0f;
 		public float maximumHeight = 0f;
+		[Tooltip("Scale factor to multiply the extrusion value of the feature.")]
 		public float extrusionScaleFactor = 1f;
 	}
 

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
@@ -139,11 +139,17 @@
 	}
 	public enum ExtrusionType
 	{
+		[Description("No extrusion.")]
 		None,
+		[Description("Extrude features using the property value.")]
 		PropertyHeight,
+		[Description("Extrude features using the property value. Values lower than min value are clamped at min value.")]
 		MinHeight,
+		[Description("Extrude features using the property value. Values higher than max value are clamped at max value.")]
 		MaxHeight,
+		[Description("Extrude features using the property value. Values are clamped in to min and max values if they are lower or greater than min,max values respectively.")]
 		RangeHeight,
+		[Description("Extrude all features using the fixed value.")]
 		AbsoluteHeight,
 	}
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
@@ -63,6 +63,11 @@
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), minHeightProperty);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), maxHeightProperty);
+					if (minHeightProperty.floatValue > maxHeightProperty.floatValue)
+					{
+						//position.y += lineHeight;
+						EditorGUILayout.HelpBox("Maximum Height less than Minimum Height!", MessageType.Error);
+					}
 					break;
 				case Unity.Map.ExtrusionType.AbsoluteHeight:
 					position.y += lineHeight;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
@@ -70,6 +70,8 @@
 				default:
 					break;
 			}
+			position.y += lineHeight;
+			EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionScaleFactor"), new GUIContent { text = "Scale Factor" });
 			EditorGUI.indentLevel--;
 
 			EditorGUI.EndProperty();
@@ -79,7 +81,7 @@
 			var extrusionTypeProperty = property.FindPropertyRelative("extrusionType");
 			var sourceTypeValue = (Unity.Map.ExtrusionType)extrusionTypeProperty.enumValueIndex;
 
-			int rows = 0;
+			int rows = 1;
 			//if (showPosition)
 			{
 				switch (sourceTypeValue)

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
@@ -3,6 +3,7 @@
 	using UnityEditor;
 	using UnityEngine;
 	using Mapbox.Unity.Map;
+	using Mapbox.VectorTile.ExtensionMethods;
 
 	[CustomPropertyDrawer(typeof(GeometryExtrusionOptions))]
 	public class GeometryExtrusionOptionsDrawer : PropertyDrawer
@@ -12,9 +13,9 @@
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			EditorGUI.BeginProperty(position, label, property);
-
-			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent("Extrusion Type"));
 			var extrusionTypeProperty = property.FindPropertyRelative("extrusionType");
+			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent { text = "Extrusion Type", tooltip = EnumExtensions.Description((Unity.Map.ExtrusionType)extrusionTypeProperty.enumValueIndex) });
+
 
 			extrusionTypeProperty.enumValueIndex = EditorGUI.Popup(typePosition, extrusionTypeProperty.enumValueIndex, extrusionTypeProperty.enumDisplayNames);
 			var sourceTypeValue = (Unity.Map.ExtrusionType)extrusionTypeProperty.enumValueIndex;
@@ -22,6 +23,8 @@
 			var minHeightProperty = property.FindPropertyRelative("minimumHeight");
 			var maxHeightProperty = property.FindPropertyRelative("maximumHeight");
 
+			var extrusionGeometryType = property.FindPropertyRelative("extrusionGeometryType");
+			var extrusionGeometryGUI = new GUIContent { text = "Extrusion Geometry Type", tooltip = EnumExtensions.Description((Unity.Map.ExtrusionGeometryType)extrusionGeometryType.enumValueIndex) };
 			EditorGUI.indentLevel++;
 			switch (sourceTypeValue)
 			{
@@ -29,13 +32,13 @@
 					break;
 				case Unity.Map.ExtrusionType.PropertyHeight:
 					position.y += lineHeight;
-					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionGeometryType"));
+					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), extrusionGeometryType, extrusionGeometryGUI);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("propertyName"));
 					break;
 				case Unity.Map.ExtrusionType.MinHeight:
 					position.y += lineHeight;
-					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionGeometryType"));
+					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), extrusionGeometryType, extrusionGeometryGUI);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("propertyName"));
 					position.y += lineHeight;
@@ -44,7 +47,7 @@
 					break;
 				case Unity.Map.ExtrusionType.MaxHeight:
 					position.y += lineHeight;
-					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionGeometryType"));
+					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), extrusionGeometryType, extrusionGeometryGUI);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("propertyName"));
 					position.y += lineHeight;
@@ -53,7 +56,7 @@
 					break;
 				case Unity.Map.ExtrusionType.RangeHeight:
 					position.y += lineHeight;
-					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionGeometryType"));
+					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), extrusionGeometryType, extrusionGeometryGUI);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("propertyName"));
 					position.y += lineHeight;
@@ -63,7 +66,7 @@
 					break;
 				case Unity.Map.ExtrusionType.AbsoluteHeight:
 					position.y += lineHeight;
-					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("extrusionGeometryType"));
+					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), extrusionGeometryType, extrusionGeometryGUI);
 					position.y += lineHeight;
 					EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), maxHeightProperty, new GUIContent { text = "Height" });
 					break;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
@@ -246,8 +246,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 						if (feature.Properties.ContainsKey("min_height"))
 						{
 							var featureMinHeight = Convert.ToSingle(feature.Properties["min_height"]);
-							minHeight = Math.Min(Math.Max(_options.minimumHeight, featureMinHeight), _options.maximumHeight);
-							//maxHeight -= minHeight;
+							minHeight = Math.Min(featureMinHeight, _options.maximumHeight);
 						}
 					}
 					break;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
@@ -39,17 +39,6 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Height Modifier")]
 	public class HeightModifier : MeshModifier
 	{
-		//[SerializeField]
-		//[Tooltip("Flatten top polygons to prevent unwanted slanted roofs because of the bumpy terrain")]
-		//private bool _flatTops;
-
-		//[SerializeField]
-		//[Tooltip("Fix all features to certain height, suggested to be used for pushing roads above terrain level to prevent z-fighting.")]
-		//private bool _forceHeight;
-
-		//[SerializeField]
-		//[Tooltip("Fixed height value for ForceHeight option")]
-		//private float _height;
 		private float _scale = 1;
 
 		//[SerializeField]
@@ -99,7 +88,8 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			GenerateWallMesh(md);
 
 		}
-		private void GenerateWallMesh(MeshData md)
+
+		protected virtual void GenerateWallMesh(MeshData md)
 		{
 			md.Vertices.Capacity = _counter + md.Edges.Count * 2;
 			float d = 0f;
@@ -170,7 +160,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			}
 		}
 
-		private void GenerateRoofMesh(MeshData md, float minHeight, float maxHeight)
+		protected virtual void GenerateRoofMesh(MeshData md, float minHeight, float maxHeight)
 		{
 			if (_options.extrusionGeometryType != ExtrusionGeometryType.SideOnly)
 			{
@@ -206,6 +196,10 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 						}
 						break;
 					case ExtrusionType.RangeHeight:
+						for (int i = 0; i < _counter; i++)
+						{
+							md.Vertices[i] = new Vector3(md.Vertices[i].x, md.Vertices[i].y + maxHeight, md.Vertices[i].z);
+						}
 						break;
 					case ExtrusionType.AbsoluteHeight:
 						for (int i = 0; i < _counter; i++)
@@ -219,7 +213,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			}
 		}
 
-		private void QueryHeight(VectorFeatureUnity feature, MeshData md, UnityTile tile, out float maxHeight, out float minHeight)
+		protected virtual void QueryHeight(VectorFeatureUnity feature, MeshData md, UnityTile tile, out float maxHeight, out float minHeight)
 		{
 			minHeight = 0.0f;
 			maxHeight = 0.0f;
@@ -246,6 +240,12 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 					{
 						var featureHeight = Convert.ToSingle(feature.Properties[_options.propertyName]);
 						maxHeight = Math.Min(Math.Max(_options.minimumHeight, featureHeight), _options.maximumHeight);
+						if (feature.Properties.ContainsKey("min_height"))
+						{
+							var featureMinHeight = Convert.ToSingle(feature.Properties["min_height"]);
+							minHeight = Math.Min(Math.Max(_options.minimumHeight, featureMinHeight), _options.maximumHeight);
+							//maxHeight -= minHeight;
+						}
 					}
 					break;
 				case ExtrusionType.AbsoluteHeight:

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
@@ -241,6 +241,13 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 				case ExtrusionType.RangeHeight:
 					if (feature.Properties.ContainsKey(_options.propertyName))
 					{
+						if (_options.minimumHeight > _options.maximumHeight)
+						{
+							Debug.LogError("Maximum Height less than Minimum Height.Swapping values for extrusion.");
+							var temp = _options.minimumHeight;
+							_options.minimumHeight = _options.maximumHeight;
+							_options.maximumHeight = temp;
+						}
 						var featureHeight = Convert.ToSingle(feature.Properties[_options.propertyName]);
 						maxHeight = Math.Min(Math.Max(_options.minimumHeight, featureHeight), _options.maximumHeight);
 						if (feature.Properties.ContainsKey("min_height"))

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/HeightModifier.cs
@@ -78,10 +78,13 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 
 			float maxHeight = 1.0f;
 			float minHeight = 0.0f;
+
 			QueryHeight(feature, md, tile, out maxHeight, out minHeight);
-			height = (maxHeight - minHeight) * _scale;
-			maxHeight = maxHeight * _scale;
-			minHeight = minHeight * _scale;
+
+			maxHeight = maxHeight * _options.extrusionScaleFactor * _scale;
+			minHeight = minHeight * _options.extrusionScaleFactor * _scale;
+			height = (maxHeight - minHeight);
+
 			//Set roof height 
 			GenerateRoofMesh(md, minHeight, maxHeight);
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
@@ -403,7 +403,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 						if (feature.Properties.ContainsKey("min_height"))
 						{
 							var featureMinHeight = Convert.ToSingle(feature.Properties["min_height"]);
-							minHeight = Math.Min(Math.Max(_options.minimumHeight, featureMinHeight), _options.maximumHeight);
+							minHeight = Math.Min(featureMinHeight, _options.maximumHeight);
 							//maxHeight -= minHeight;
 						}
 					}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
@@ -87,17 +87,11 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 
 			//read or force height
 			float maxHeight = 1, minHeight = 0;
-			//SetHeight(feature, md, tile, out maxHeight, out minHeight);
-			//height = maxHeight - minHeight;
-			//for (int i = 0; i < md.Vertices.Count; i++)
-			//{
-			//	md.Vertices[i] = new Vector3(md.Vertices[i].x, md.Vertices[i].y + maxHeight, md.Vertices[i].z);
-			//}
 
 			QueryHeight(feature, md, tile, out maxHeight, out minHeight);
-			height = (maxHeight - minHeight) * _scale;
-			maxHeight = maxHeight * _scale;
-			minHeight = minHeight * _scale;
+			maxHeight = maxHeight * _options.extrusionScaleFactor * _scale;
+			minHeight = minHeight * _options.extrusionScaleFactor * _scale;
+			height = (maxHeight - minHeight);
 
 			GenerateRoofMesh(md, minHeight, maxHeight);
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
@@ -398,6 +398,13 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 				case ExtrusionType.RangeHeight:
 					if (feature.Properties.ContainsKey(_options.propertyName))
 					{
+						if (_options.minimumHeight > _options.maximumHeight)
+						{
+							Debug.LogError("Maximum Height less than Minimum Height.Swapping values for extrusion.");
+							var temp = _options.minimumHeight;
+							_options.minimumHeight = _options.maximumHeight;
+							_options.maximumHeight = temp;
+						}
 						var featureHeight = Convert.ToSingle(feature.Properties[_options.propertyName]);
 						maxHeight = Math.Min(Math.Max(_options.minimumHeight, featureHeight), _options.maximumHeight);
 						if (feature.Properties.ContainsKey("min_height"))

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/TextureSideWallModifier.cs
@@ -9,11 +9,6 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Textured Side Wall Modifier")]
 	public class TextureSideWallModifier : MeshModifier
 	{
-		//[SerializeField]
-		//private float _height;
-		//[SerializeField]
-		//private bool _forceHeight;
-
 		private float _scaledFloorHeight = 0;
 		private float _scaledFirstFloorHeight = 0;
 		private float _scaledTopFloorHeight = 0;
@@ -367,6 +362,10 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 						}
 						break;
 					case ExtrusionType.RangeHeight:
+						for (int i = 0; i < _counter; i++)
+						{
+							md.Vertices[i] = new Vector3(md.Vertices[i].x, md.Vertices[i].y + maxHeight, md.Vertices[i].z);
+						}
 						break;
 					case ExtrusionType.AbsoluteHeight:
 						for (int i = 0; i < _counter; i++)
@@ -407,6 +406,12 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 					{
 						var featureHeight = Convert.ToSingle(feature.Properties[_options.propertyName]);
 						maxHeight = Math.Min(Math.Max(_options.minimumHeight, featureHeight), _options.maximumHeight);
+						if (feature.Properties.ContainsKey("min_height"))
+						{
+							var featureMinHeight = Convert.ToSingle(feature.Properties["min_height"]);
+							minHeight = Math.Min(Math.Max(_options.minimumHeight, featureMinHeight), _options.maximumHeight);
+							//maxHeight -= minHeight;
+						}
 					}
 					break;
 				case ExtrusionType.AbsoluteHeight:


### PR DESCRIPTION
**Related issue**

Closes #605 

**Description of changes**

Range Height Extrusion option was not computing the correct wall height for features. The expected behavior is - the properly value gets clipped to min value is lower or gets clipped to max value if higher than max value, unchanged if in between min & max values ( comparison is done before multiplying with the scale factor)

Adds a Scale Factor to scale the values by this value. 

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [x] Update documentation.

**Reviewers**

@apavani @brnkhy 
