### PR TITLE
Fix tile position issue with vector features.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
@@ -182,17 +182,23 @@
 
 		void DrawModifiers(SerializedProperty property, GUIContent label)
 		{
+			var groupFeaturesProperty = property.FindPropertyRelative("coreOptions").FindPropertyRelative("groupFeatures");
 			showPosition = EditorGUILayout.Foldout(showPosition, label.text);
 			EditorGUILayout.BeginVertical();
 			if (showPosition)
 			{
+
 				EditorGUILayout.BeginHorizontal();
-				EditorGUILayout.PrefixLabel(new GUIContent { text = "Feature Position", tooltip = "Position to place feature in the tile. " });
-				var featurePositionProperty = property.FindPropertyRelative("moveFeaturePositionTo");
-				featurePositionProperty.enumValueIndex = EditorGUILayout.Popup(featurePositionProperty.enumValueIndex, featurePositionProperty.enumDisplayNames);
+				if (groupFeaturesProperty.boolValue == false)
+				{
+					EditorGUILayout.PrefixLabel(new GUIContent { text = "Feature Position", tooltip = "Position to place feature in the tile. " });
+					var featurePositionProperty = property.FindPropertyRelative("moveFeaturePositionTo");
+					featurePositionProperty.enumValueIndex = EditorGUILayout.Popup(featurePositionProperty.enumValueIndex, featurePositionProperty.enumDisplayNames);
+				}
 				EditorGUILayout.EndHorizontal();
 
 				EditorGUILayout.Space();
+
 				EditorGUILayout.LabelField(new GUIContent { text = "Mesh Modifiers", tooltip = "Modifiers that manipulate the features mesh. " });
 
 				var meshfac = property.FindPropertyRelative("MeshModifiers");

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -46,6 +46,7 @@
 			else
 			{
 				_defaultStack = ScriptableObject.CreateInstance<ModifierStack>();
+				((ModifierStack)_defaultStack).moveFeaturePositionTo = _layerProperties.moveFeaturePositionTo;
 			}
 
 			_defaultStack.MeshModifiers = new List<MeshModifier>();

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStack.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStack.cs
@@ -38,7 +38,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Modifier Stack")]
 	public class ModifierStack : ModifierStackBase
 	{
-		[SerializeField] private PositionTargetType _moveFeaturePositionTo;
+		[SerializeField] public PositionTargetType moveFeaturePositionTo;
 
 
 		[NonSerialized] private int vertexIndex = 1;
@@ -120,14 +120,14 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			_counter = feature.Points.Count;
 			_secondCounter = 0;
 
-			if (_moveFeaturePositionTo != PositionTargetType.TileCenter)
+			if (moveFeaturePositionTo != PositionTargetType.TileCenter)
 			{
 				_tempPoint = Constants.Math.Vector3Zero;
-				if (_moveFeaturePositionTo == PositionTargetType.FirstVertex)
+				if (moveFeaturePositionTo == PositionTargetType.FirstVertex)
 				{
 					_tempPoint = feature.Points[0][0];
 				}
-				else if (_moveFeaturePositionTo == PositionTargetType.CenterOfVertices)
+				else if (moveFeaturePositionTo == PositionTargetType.CenterOfVertices)
 				{
 					//this is not precisely the center because of the duplicates  (first/last vertex) but close to center
 					_tempPoint = feature.Points[0][0];


### PR DESCRIPTION
**Related issue**

Closes #615 

**Description of changes**

Property in the inspector was not being set in the actual modifier stack. 
Changed inspector to not show the `Tile Position` option for grouped features. 

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [x] Update documentation.

**Reviewers**


