### PR TITLE
Make filter values case - insensitive.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -294,7 +294,7 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 
 		[Tooltip("Filter operator to apply. ")]
 		public LayerFilterOperationType filterOperator;
-
+		private char[] _delimiters = new char[] { ',' };
 		public LayerFilter(LayerFilterOperationType filterOperation)
 		{
 			filterOperator = filterOperation;
@@ -302,6 +302,10 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 
 		public ILayerFeatureFilterComparer GetFilterComparer()
 		{
+			if (_delimiters == null)
+			{
+				_delimiters = new char[] { ',' };
+			}
 			ILayerFeatureFilterComparer filterComparer = new LayerFilterComparer();
 
 			switch (filterOperator)
@@ -316,7 +320,10 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 					filterComparer = LayerFilterComparer.HasPropertyLessThan(Key, Min);
 					break;
 				case LayerFilterOperationType.Contains:
-					filterComparer = LayerFilterComparer.PropertyContainsValue(Key, PropertyValue.ToLower().Split(','));
+					var matchList = PropertyValue.ToLower().Split(_delimiters, StringSplitOptions.RemoveEmptyEntries)
+												 .Select(p => p.Trim())
+												 .Where(tag => !string.IsNullOrEmpty(tag));
+					filterComparer = LayerFilterComparer.PropertyContainsValue(Key, matchList);
 					break;
 				case LayerFilterOperationType.IsInRange:
 					filterComparer = LayerFilterComparer.HasPropertyInRange(Key, Min, Max);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -320,9 +320,11 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 					filterComparer = LayerFilterComparer.HasPropertyLessThan(Key, Min);
 					break;
 				case LayerFilterOperationType.Contains:
-					var matchList = PropertyValue.ToLower().Split(_delimiters, StringSplitOptions.RemoveEmptyEntries)
-												 .Select(p => p.Trim())
-												 .Where(tag => !string.IsNullOrEmpty(tag));
+					var matchList = PropertyValue.ToLower()
+						.Split(_delimiters, StringSplitOptions.RemoveEmptyEntries)
+						.Select(p => p.Trim())
+						.Where(p => !string.IsNullOrEmpty(p))
+						.ToArray();
 					filterComparer = LayerFilterComparer.PropertyContainsValue(Key, matchList);
 					break;
 				case LayerFilterOperationType.IsInRange:

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -278,7 +278,7 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 
 		protected override bool PropertyComparer(object property)
 		{
-			return ValueSet.Contains(property);
+			return ValueSet.Contains(property.ToString().ToLower());
 		}
 	}
 
@@ -316,7 +316,7 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 					filterComparer = LayerFilterComparer.HasPropertyLessThan(Key, Min);
 					break;
 				case LayerFilterOperationType.Contains:
-					filterComparer = LayerFilterComparer.PropertyContainsValue(Key, PropertyValue.Split(','));
+					filterComparer = LayerFilterComparer.PropertyContainsValue(Key, PropertyValue.ToLower().Split(','));
 					break;
 				case LayerFilterOperationType.IsInRange:
 					filterComparer = LayerFilterComparer.HasPropertyInRange(Key, Min, Max);


### PR DESCRIPTION

**Description of changes**
string property values in filters were case sensitive. This fix changes them to be case -insensitive. 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
