### PR TITLE
Collider Dropdown in Abstract Map for adding colliders on top of extruded geometry

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs
@@ -1,19 +1,23 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using Mapbox.Unity.MeshGeneration.Modifiers;
-using System;
-using Mapbox.Unity.Map;
-
-public class ColliderOptions : ModifierProperties
+﻿namespace Mapbox.Unity.Map
 {
-	public override Type ModifierType
-	{
-		get
-		{
-			return typeof(ColliderModifier);
-		}
-	}
+	using System.Collections;
+	using System.Collections.Generic;
+	using UnityEngine;
+	using Mapbox.Unity.MeshGeneration.Modifiers;
+	using System;
+	using Mapbox.Unity.Map;
 
-	public ColliderType colliderType = ColliderType.None;
+	[Serializable]
+	public class ColliderOptions : ModifierProperties
+	{
+		public override Type ModifierType
+		{
+			get
+			{
+				return typeof(ColliderModifier);
+			}
+		}
+
+		public ColliderType colliderType = ColliderType.None;
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Mapbox.Unity.MeshGeneration.Modifiers;
+using System;
+using Mapbox.Unity.Map;
+
+public class ColliderOptions : ModifierProperties
+{
+	public override Type ModifierType
+	{
+		get
+		{
+			return typeof(ColliderModifier);
+		}
+	}
+
+	public ColliderType colliderType = ColliderType.None;
+}

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/ColliderOptions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f38b85c80ace3431c90c6b093436742d
+timeCreated: 1522459497
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
@@ -159,13 +159,13 @@
 
 	public enum ColliderType
 	{
-		[Description("No collider")]
+		[Description("No collider.")]
 		None,
-		[Description("Box collider addded to the GameObject")]
+		[Description("Box collider addded to the GameObject.")]
 		BoxCollider,
-		[Description("Mesh collider added to the GameObject")]
+		[Description("Mesh collider added to the GameObject.")]
 		MeshCollider,
-		[Description("Sphere collider added to the GameObject")]
+		[Description("Sphere collider added to the GameObject.")]
 		SphereCollider,
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
@@ -156,4 +156,16 @@
 		[Description("Extrudes only side wall geometry of the vector feature.")]
 		SideOnly,
 	}
+
+	public enum ColliderType
+	{
+		[Description("No collider added to the extruded geometry")]
+		None,
+		[Description("Box collider addded to the extruded geometry")]
+		BoxCollider,
+		[Description("Mesh collider added to the extruded geometry")]
+		MeshCollider,
+		[Description("Sphere collider added to the extruded geometry")]
+		SphereCollider,
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
@@ -159,13 +159,13 @@
 
 	public enum ColliderType
 	{
-		[Description("No collider added to the extruded geometry")]
+		[Description("No collider")]
 		None,
-		[Description("Box collider addded to the extruded geometry")]
+		[Description("Box collider addded to the GameObject")]
 		BoxCollider,
-		[Description("Mesh collider added to the extruded geometry")]
+		[Description("Mesh collider added to the GameObject")]
 		MeshCollider,
-		[Description("Sphere collider added to the extruded geometry")]
+		[Description("Sphere collider added to the GameObject")]
 		SphereCollider,
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
@@ -5,6 +5,7 @@
 	using UnityEditor;
 	using UnityEngine;
 	using Mapbox.Unity.Map;
+	using Mapbox.VectorTile.ExtensionMethods;
 
 	[CustomPropertyDrawer(typeof(ColliderOptions))]
 	public class ColliderOptionsDrawer : PropertyDrawer
@@ -15,6 +16,7 @@
 			EditorGUI.BeginProperty(position, label, property);
 			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent("Collider Type"));
 			var colliderTypeProperty = property.FindPropertyRelative("colliderType");
+			typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent { text = "Collider Type", tooltip = EnumExtensions.Description((Unity.Map.ColliderType)colliderTypeProperty.enumValueIndex) });
 
 			colliderTypeProperty.enumValueIndex = EditorGUI.Popup(typePosition, colliderTypeProperty.enumValueIndex, colliderTypeProperty.enumDisplayNames);
 			var sourceTypeValue = (Unity.Map.ExtrusionType)colliderTypeProperty.enumValueIndex;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
@@ -1,15 +1,29 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
-using UnityEngine;
-
-[CustomPropertyDrawer(typeof(ColliderOptions))]
-public class ColliderOptionsDrawer : PropertyDrawer
+﻿namespace Mapbox.Editor
 {
+	using System.Collections;
+	using System.Collections.Generic;
+	using UnityEditor;
+	using UnityEngine;
+	using Mapbox.Unity.Map;
 
-	static float lineHeight = EditorGUIUtility.singleLineHeight;
-	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+	[CustomPropertyDrawer(typeof(ColliderOptions))]
+	public class ColliderOptionsDrawer : PropertyDrawer
 	{
-		//logic to draw the property
+		static float lineHeight = EditorGUIUtility.singleLineHeight;
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			EditorGUI.BeginProperty(position, label, property);
+			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent("Collider Type"));
+			var colliderTypeProperty = property.FindPropertyRelative("colliderType");
+
+			colliderTypeProperty.enumValueIndex = EditorGUI.Popup(typePosition, colliderTypeProperty.enumValueIndex, colliderTypeProperty.enumDisplayNames);
+			var sourceTypeValue = (Unity.Map.ExtrusionType)colliderTypeProperty.enumValueIndex;
+			EditorGUI.EndProperty();
+		}
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return lineHeight;
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(ColliderOptions))]
+public class ColliderOptionsDrawer : PropertyDrawer
+{
+
+	static float lineHeight = EditorGUIUtility.singleLineHeight;
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+	{
+		//logic to draw the property
+	}
+}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs
@@ -14,11 +14,18 @@
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			EditorGUI.BeginProperty(position, label, property);
-			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent("Collider Type"));
+			var typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent { text = "Collider Type", tooltip = "The type of collider added to game objects in this layer." });
 			var colliderTypeProperty = property.FindPropertyRelative("colliderType");
-			typePosition = EditorGUI.PrefixLabel(new Rect(position.x, position.y, position.width, lineHeight), GUIUtility.GetControlID(FocusType.Passive), new GUIContent { text = "Collider Type", tooltip = EnumExtensions.Description((Unity.Map.ColliderType)colliderTypeProperty.enumValueIndex) });
 
-			colliderTypeProperty.enumValueIndex = EditorGUI.Popup(typePosition, colliderTypeProperty.enumValueIndex, colliderTypeProperty.enumDisplayNames);
+			List<GUIContent> enumContent = new List<GUIContent>();
+			foreach(var enumValue in colliderTypeProperty.enumDisplayNames)
+			{
+				var guiContent =  new GUIContent { text = enumValue, tooltip =  EnumExtensions.Description((Unity.Map.ColliderType)colliderTypeProperty.enumValueIndex)} ;
+				enumContent.Add(guiContent);
+			}
+
+
+			colliderTypeProperty.enumValueIndex = EditorGUI.Popup(typePosition, colliderTypeProperty.enumValueIndex, enumContent.ToArray());
 			var sourceTypeValue = (Unity.Map.ExtrusionType)colliderTypeProperty.enumValueIndex;
 			EditorGUI.EndProperty();
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ColliderOptionsDrawer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 05ab73c42b3654a68823b6793c470531
+timeCreated: 1522459817
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
@@ -88,20 +88,20 @@
 						rows += 1;
 						break;
 					case Unity.Map.ExtrusionType.PropertyHeight:
-						rows += 4;
+						rows += 3;
 						break;
 					case Unity.Map.ExtrusionType.MinHeight:
 					case Unity.Map.ExtrusionType.MaxHeight:
-						rows += 5;
-						break;
-					case Unity.Map.ExtrusionType.RangeHeight:
-						rows += 6;
-						break;
-					case Unity.Map.ExtrusionType.AbsoluteHeight:
 						rows += 4;
 						break;
-					default:
+					case Unity.Map.ExtrusionType.RangeHeight:
+						rows += 5;
+						break;
+					case Unity.Map.ExtrusionType.AbsoluteHeight:
 						rows += 3;
+						break;
+					default:
+						rows += 2;
 						break;
 				}
 			}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryExtrusionOptionsDrawer.cs
@@ -88,20 +88,20 @@
 						rows += 1;
 						break;
 					case Unity.Map.ExtrusionType.PropertyHeight:
-						rows += 3;
+						rows += 4;
 						break;
 					case Unity.Map.ExtrusionType.MinHeight:
 					case Unity.Map.ExtrusionType.MaxHeight:
-						rows += 4;
-						break;
-					case Unity.Map.ExtrusionType.RangeHeight:
 						rows += 5;
 						break;
+					case Unity.Map.ExtrusionType.RangeHeight:
+						rows += 6;
+						break;
 					case Unity.Map.ExtrusionType.AbsoluteHeight:
-						rows += 3;
+						rows += 4;
 						break;
 					default:
-						rows += 2;
+						rows += 3;
 						break;
 				}
 			}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
@@ -160,9 +160,9 @@
 
 			if (primitiveTypeProp != VectorPrimitiveType.Point && primitiveTypeProp != VectorPrimitiveType.Custom)
 			{
-				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("extrusionOptions"));
-
 				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("colliderOptions"));
+
+				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("extrusionOptions"));
 
 				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("materialOptions"));
 			}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
@@ -114,6 +114,8 @@
 					var subLayerExtrusionOptions = subLayer.FindPropertyRelative("extrusionOptions");
 					subLayerExtrusionOptions.FindPropertyRelative("propertyName").stringValue = "height";
 
+					var subLayerColliderOptions = subLayer.FindPropertyRelative("colliderOptions");
+					subLayerColliderOptions.FindPropertyRelative("colliderType").enumValueIndex = (int)ColliderType.None;
 				}
 				if (GUILayout.Button(new GUIContent("Remove Selected"), (GUIStyle)"minibuttonright"))
 				{
@@ -148,7 +150,7 @@
 
 		void DrawLayerVisualizerProperties(SerializedProperty layerProperty)
 		{
-			GUILayout.Label("Vector Layer Visualizer Properties");
+ 			GUILayout.Label("Vector Layer Visualizer Properties");
 			GUILayout.BeginVertical();
 
 			var subLayerCoreOptions = layerProperty.FindPropertyRelative("coreOptions");
@@ -159,6 +161,8 @@
 			if (primitiveTypeProp != VectorPrimitiveType.Point && primitiveTypeProp != VectorPrimitiveType.Custom)
 			{
 				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("extrusionOptions"));
+
+				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("colliderOptions"));
 
 				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("materialOptions"));
 			}

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
@@ -17,7 +17,10 @@
 			extrusionGeometryType = ExtrusionGeometryType.RoofAndSide,
 
 		};
-		public ColliderOptions colliderOptions = new ColliderOptions();
+		public ColliderOptions colliderOptions = new ColliderOptions
+		{
+			colliderType = ColliderType.None,
+		};
 		public GeometryMaterialOptions materialOptions = new GeometryMaterialOptions();
 
 		public bool buildingsWithUniqueIds = false;

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
@@ -17,6 +17,7 @@
 			extrusionGeometryType = ExtrusionGeometryType.RoofAndSide,
 
 		};
+		public ColliderOptions colliderOptions = new ColliderOptions();
 		public GeometryMaterialOptions materialOptions = new GeometryMaterialOptions();
 
 		public bool buildingsWithUniqueIds = false;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -79,6 +79,11 @@
 					{
 						defaultMeshModifierStack.Add(CreateInstance<SnapTerrainModifier>());
 					}
+					//collider modifier options
+					var lineColliderMod = CreateInstance<ColliderModifier>();
+					lineColliderMod.SetProperties(_layerProperties.colliderOptions);
+					defaultGOModifierStack.Add(lineColliderMod);
+
 					var lineMatMod = CreateInstance<MaterialModifier>();
 					lineMatMod.SetProperties(_layerProperties.materialOptions);
 					defaultGOModifierStack.Add(lineMatMod);
@@ -114,6 +119,11 @@
 							defaultMeshModifierStack.Add(heightMod);
 						}
 					}
+
+					//collider modifier options
+					var polyColliderMod = CreateInstance<ColliderModifier>();
+					polyColliderMod.SetProperties(_layerProperties.colliderOptions);
+					defaultGOModifierStack.Add(polyColliderMod);
 
 					var matMod = CreateInstance<MaterialModifier>();
 					matMod.SetProperties(_layerProperties.materialOptions);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -79,10 +79,14 @@
 					{
 						defaultMeshModifierStack.Add(CreateInstance<SnapTerrainModifier>());
 					}
+
 					//collider modifier options
-					var lineColliderMod = CreateInstance<ColliderModifier>();
-					lineColliderMod.SetProperties(_layerProperties.colliderOptions);
-					defaultGOModifierStack.Add(lineColliderMod);
+					if (_layerProperties.colliderOptions.colliderType != ColliderType.None)
+					{
+						var lineColliderMod = CreateInstance<ColliderModifier>();
+						lineColliderMod.SetProperties(_layerProperties.colliderOptions);
+						defaultGOModifierStack.Add(lineColliderMod);
+					}
 
 					var lineMatMod = CreateInstance<MaterialModifier>();
 					lineMatMod.SetProperties(_layerProperties.materialOptions);
@@ -121,9 +125,12 @@
 					}
 
 					//collider modifier options
-					var polyColliderMod = CreateInstance<ColliderModifier>();
-					polyColliderMod.SetProperties(_layerProperties.colliderOptions);
-					defaultGOModifierStack.Add(polyColliderMod);
+					if (_layerProperties.colliderOptions.colliderType != ColliderType.None)
+					{
+						var polyColliderMod = CreateInstance<ColliderModifier>();
+						polyColliderMod.SetProperties(_layerProperties.colliderOptions);
+						defaultGOModifierStack.Add(polyColliderMod);
+					}
 
 					var matMod = CreateInstance<MaterialModifier>();
 					matMod.SetProperties(_layerProperties.materialOptions);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
@@ -10,15 +10,15 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Collider Modifier")]
 	public class ColliderModifier : GameObjectModifier
 	{
-		[SerializeField]
-		private ColliderType _colliderType;
+		//[SerializeField]
+		//private ColliderType _colliderType;
 		private IColliderStrategy _colliderStrategy;
 
-		GeometryExtrusionOptions _options;
+		ColliderOptions _options;
 
 		public override void SetProperties(ModifierProperties properties)
 		{
-			_options = (GeometryExtrusionOptions)properties;
+			_options = (ColliderOptions)properties;
 		}
 
 		public override void Initialize()
@@ -27,7 +27,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			//creating a new one iff we don't already have one. if you want to reset/recreate you have to clear stuff inside current/old one first.
 			if (_colliderStrategy == null)
 			{
-				switch (_colliderType)
+				switch (_options.colliderType)
 				{
 					case ColliderType.None:
 						_colliderStrategy = null;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
@@ -5,6 +5,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 	using Mapbox.Unity.MeshGeneration.Components;
 	using System.Collections.Generic;
 	using System;
+	using Mapbox.Unity.Map;
 
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Collider Modifier")]
 	public class ColliderModifier : GameObjectModifier
@@ -13,6 +14,12 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		private ColliderType _colliderType;
 		private IColliderStrategy _colliderStrategy;
 
+		GeometryExtrusionOptions _options;
+
+		public override void SetProperties(ModifierProperties properties)
+		{
+			_options = (GeometryExtrusionOptions)properties;
+		}
 
 		public override void Initialize()
 		{
@@ -48,14 +55,6 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 				_colliderStrategy.AddColliderTo(ve);
 			}
 
-		}
-
-		public enum ColliderType
-		{
-			None,
-			BoxCollider,
-			MeshCollider,
-			SphereCollider
 		}
 
 		public class BoxColliderStrategy : IColliderStrategy


### PR DESCRIPTION
**Related issue**

Closes https://github.com/mapbox/unity/issues/530

**Description of changes**
Added a drop down to pick a type of collider that would go on top of extruded geomtery

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
