### PR TITLE
Disable buildingsWithUniqueIds setting for MapboxStreets data source. 

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -8,6 +8,7 @@
 - Add scale factor for extrusion value derived from feature property.
 
 ##### Bug Fixes
+- Remove `buildingsWithUniqueIds` setting for `Mapbox Streets` data source.
 - Change `Style Name` to `Data Source`
 - Fix to make filter values case insensitive.
 - Fix issue where position vector features was not being set.

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
@@ -218,7 +218,7 @@
 					var layerProperty = subLayerArray.GetArrayElementAtIndex(SelectionIndex);
 
 					layerProperty.isExpanded = true;
-					DrawLayerVisualizerProperties(layerProperty);
+					DrawLayerVisualizerProperties(sourceTypeValue,layerProperty);
 				}
 				else
 				{
@@ -228,7 +228,7 @@
 			EditorGUI.EndProperty();
 		}
 
-		void DrawLayerVisualizerProperties(SerializedProperty layerProperty)
+		void DrawLayerVisualizerProperties(VectorSourceType sourceType, SerializedProperty layerProperty)
 		{
 			EditorGUI.indentLevel++;
 			GUILayout.Label("Vector Layer Visualizer Properties");
@@ -252,11 +252,16 @@
 			EditorGUI.indentLevel++;
 			if (ShowOthers)
 			{
-				if (primitiveTypeProp == VectorPrimitiveType.Polygon)
+				if (primitiveTypeProp == VectorPrimitiveType.Polygon && sourceType != VectorSourceType.MapboxStreets)
 				{
 					EditorGUI.indentLevel--;
+					layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue = true;
 					EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("buildingsWithUniqueIds"), new GUIContent { text = "Buildings With Unique Ids", tooltip = "Turn on this setting only when rendering 3D buildings from the Mapbox Streets with Building Ids tileset. Using this setting with any other polygon layers or source will result in visual artifacts. " });
 					EditorGUI.indentLevel++;
+				}
+				else
+				{
+					layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue = false;
 				}
 				EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("filterOptions"), new GUIContent("Filters"));
 				//EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("modifierOptions"), new GUIContent("Modifiers"));

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/VectorSubLayerProperties.cs
@@ -22,7 +22,8 @@
 			colliderType = ColliderType.None,
 		};
 		public GeometryMaterialOptions materialOptions = new GeometryMaterialOptions();
-
+		//HACK : workaround to avoid users accidentaly leaving the buildingsWithUniqueIds settign on and have missing buildings. 
+		public bool honorBuildingIdSetting = true;
 		public bool buildingsWithUniqueIds = false;
 		public PositionTargetType moveFeaturePositionTo;
 		[NodeEditorElement("Mesh Modifiers")]

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -214,10 +214,13 @@
 			for (int i = 0; i < fc; i++)
 			{
 
-				var feature = new VectorFeatureUnity(layer.GetFeature(i), tile, layer.Extent, _layerProperties.buildingsWithUniqueIds);
+				var buildingsWithUniqueIds =
+					(_layerProperties.honorBuildingIdSetting) && _layerProperties.buildingsWithUniqueIds;
+
+				var feature = new VectorFeatureUnity(layer.GetFeature(i), tile, layer.Extent, buildingsWithUniqueIds);
 
 				//skip existing features, only works on tilesets with unique ids
-				if (_layerProperties.buildingsWithUniqueIds && _activeIds.Contains(feature.Data.Id))
+				if (buildingsWithUniqueIds && _activeIds.Contains(feature.Data.Id))
 				{
 					continue;
 				}


### PR DESCRIPTION

**Description of changes**
Added a workaround in the UI to prevent users from accidentally filtering out building with MapboxStreets datasource. The setting will not be honored when using Mapbox streets or any non -polygon layers. 

**EDIT** 
To test, load building with `Mapbox Streets with building Ids`  and turn on the `buildingsWithUniqueIds` setting. Then change data source to `Mapbox Streets` . Same number of buildings should be rendered in both cases. 
**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

cc @brnkhy @BergWerkGIS @apavani 
