### PR TITLE
Disable InitializeOnStart when `InitializeWithLocationProvider` is used. 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -62,13 +62,28 @@ namespace Mapbox.Unity.Map
 	}
 	/// <summary>
 	/// Abstract map.
-	/// This is the main monobehavior which controls the map. It controls the visualization of map data. 
-	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map. 
+	/// This is the main monobehavior which controls the map. It controls the visualization of map data.
+	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	public class AbstractMap : MonoBehaviour, IMap
 	{
+		/// <summary>
+		/// Setting to trigger map initialization in Unity's Start method.
+		/// if set to false, Initialize method should be called explicitly to initialize the map.
+		/// </summary>
 		[SerializeField]
 		private bool _initializeOnStart = true;
+		public bool InitializeOnStart
+		{
+			get
+			{
+				return _initializeOnStart;
+			}
+			set
+			{
+				_initializeOnStart = value;
+			}
+		}
 		/// <summary>
 		/// The map options.
 		/// Options to control the behaviour of the map like location,extent, scale and placement.
@@ -87,7 +102,7 @@ namespace Mapbox.Unity.Map
 			}
 		}
 		/// <summary>
-		/// Options to control the imagery component of the map. 
+		/// Options to control the imagery component of the map.
 		/// </summary>
 		[SerializeField]
 		ImageryLayer _imagery = new ImageryLayer();
@@ -114,8 +129,8 @@ namespace Mapbox.Unity.Map
 		}
 		/// <summary>
 		/// The vector data.
-		/// Options to control the vector data component of the map. 
-		/// Adds a vector source and visualizers to define the rendering behaviour of vector data layers. 
+		/// Options to control the vector data component of the map.
+		/// Adds a vector source and visualizers to define the rendering behaviour of vector data layers.
 		/// </summary>
 		[SerializeField]
 		VectorLayer _vectorData = new VectorLayer();
@@ -188,8 +203,8 @@ namespace Mapbox.Unity.Map
 
 		protected int _initialZoom;
 		/// <summary>
-		/// Gets the initial zoom at which the map was initialized. 
-		/// This parameter is useful in calculating the scale of the tiles and the map. 
+		/// Gets the initial zoom at which the map was initialized.
+		/// This parameter is useful in calculating the scale of the tiles and the map.
 		/// </summary>
 		/// <value>The initial zoom.</value>
 		public int InitialZoom
@@ -233,8 +248,8 @@ namespace Mapbox.Unity.Map
 			}
 		}
 		/// <summary>
-		/// Gets the current zoom value of the map. 
-		/// Use <c>AbsoluteZoom</c> to get the zoom level of the tileset. 
+		/// Gets the current zoom value of the map.
+		/// Use <c>AbsoluteZoom</c> to get the zoom level of the tileset.
 		/// <seealso cref="AbsoluteZoom"/>
 		/// </summary>
 		/// <value>The zoom.</value>
@@ -300,8 +315,8 @@ namespace Mapbox.Unity.Map
 		}
 		/// <summary>
 		/// Sets up map.
-		/// This method uses the mapOptions and layer properties to setup the map to be rendered. 
-		/// Override <c>SetUpMap</c> to write custom behavior to map setup. 
+		/// This method uses the mapOptions and layer properties to setup the map to be rendered.
+		/// Override <c>SetUpMap</c> to write custom behavior to map setup.
 		/// </summary>
 		protected virtual void SetUpMap()
 		{
@@ -332,7 +347,7 @@ namespace Mapbox.Unity.Map
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				ITileProviderOptions tileProviderOptions = _options.extentOptions.GetTileProviderOptions();
-				// Setup tileprovider based on type. 
+				// Setup tileprovider based on type.
 				switch (_options.extentOptions.extentType)
 				{
 					case MapExtentType.CameraBounds:
@@ -431,7 +446,7 @@ namespace Mapbox.Unity.Map
 		}
 		/// <summary>
 		/// Initialize the map using the specified latLon and zoom.
-		/// Map will automatically get initialized in the <c>Start</c> method. 
+		/// Map will automatically get initialized in the <c>Start</c> method.
 		/// Use this method to explicitly initialize the map and disable intialize on <c>Start</c>
 		/// </summary>
 		/// <returns>The initialize.</returns>
@@ -451,9 +466,9 @@ namespace Mapbox.Unity.Map
 		}
 		/// <summary>
 		/// Updates the map.
-		/// Use this method to update the location of the map. 
-		/// Update method should be used when panning, zooming or changing location of the map. 
-		/// This method avoid startup delays that might occur on re-initializing the map. 
+		/// Use this method to update the location of the map.
+		/// Update method should be used when panning, zooming or changing location of the map.
+		/// This method avoid startup delays that might occur on re-initializing the map.
 		/// </summary>
 		/// <param name="latLon">LatitudeLongitude.</param>
 		/// <param name="zoom">Zoom level.</param>
@@ -473,7 +488,7 @@ namespace Mapbox.Unity.Map
 			xDelta = xDelta > 0 ? Mathd.Min(xDelta, Mapbox.Utils.Constants.LatitudeMax) : Mathd.Max(xDelta, -Mapbox.Utils.Constants.LatitudeMax);
 			zDelta = zDelta > 0 ? Mathd.Min(zDelta, Mapbox.Utils.Constants.LongitudeMax) : Mathd.Max(zDelta, -Mapbox.Utils.Constants.LongitudeMax);
 
-			//Set Center in Latitude Longitude and Mercator. 
+			//Set Center in Latitude Longitude and Mercator.
 			SetCenterLatitudeLongitude(new Vector2d(xDelta, zDelta));
 			Options.scalingOptions.scalingStrategy.SetUpScaling(this);
 
@@ -489,7 +504,7 @@ namespace Mapbox.Unity.Map
 		}
 		/// <summary>
 		/// Resets the map.
-		/// Use this method to reset the map to and reset all parameters. 
+		/// Use this method to reset the map to and reset all parameters.
 		/// </summary>
 		public void ResetMap()
 		{
@@ -545,7 +560,7 @@ namespace Mapbox.Unity.Map
 
 		internal Vector3 GeoToWorldPositionXZ(Vector2d latitudeLongitude)
 		{
-			// For quadtree implementation of the map, the map scale needs to be compensated for. 
+			// For quadtree implementation of the map, the map scale needs to be compensated for.
 			var scaleFactor = Mathf.Pow(2, (InitialZoom - AbsoluteZoom));
 			var worldPos = Conversions.GeoToWorldPosition(latitudeLongitude, CenterMercator, WorldRelativeScale * scaleFactor).ToVector3xz();
 			return Root.TransformPoint(worldPos);
@@ -570,7 +585,7 @@ namespace Mapbox.Unity.Map
 
 		}
 		/// <summary>
-		/// Converts a latitude longitude into map space position. 
+		/// Converts a latitude longitude into map space position.
 		/// </summary>
 		/// <returns>Position in map space.</returns>
 		/// <param name="latitudeLongitude">Latitude longitude.</param>
@@ -589,13 +604,13 @@ namespace Mapbox.Unity.Map
 			return worldPos;
 		}
 		/// <summary>
-		/// Converts a position in map space into a laitude longitude. 
+		/// Converts a position in map space into a laitude longitude.
 		/// </summary>
 		/// <returns>Position in Latitude longitude.</returns>
 		/// <param name="realworldPoint">Realworld point.</param>
 		public virtual Vector2d WorldToGeoPosition(Vector3 realworldPoint)
 		{
-			// For quadtree implementation of the map, the map scale needs to be compensated for. 
+			// For quadtree implementation of the map, the map scale needs to be compensated for.
 			var scaleFactor = Mathf.Pow(2, (InitialZoom - AbsoluteZoom));
 
 			return (Root.InverseTransformPoint(realworldPoint)).GetGeoPosition(CenterMercator, WorldRelativeScale * scaleFactor);

--- a/sdkproject/Assets/Mapbox/Unity/Map/InitializeMapWithLocationProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/InitializeMapWithLocationProvider.cs
@@ -11,6 +11,12 @@
 
 		ILocationProvider _locationProvider;
 
+		private void Awake()
+		{
+			// Prevent double initialization of the map. 
+			_map.InitializeOnStart = false;
+		}
+
 		IEnumerator Start()
 		{
 			yield return null;

--- a/sdkproject/Assets/Mapbox/Unity/Map/RangeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/RangeTileProvider.cs
@@ -7,15 +7,8 @@ namespace Mapbox.Unity.Map
 
 	public class RangeTileProvider : AbstractTileProvider
 	{
-		//[SerializeField]
-		//private int _west = 2;
-		//[SerializeField]
-		//private int _north = 2;
-		//[SerializeField]
-		//private int _east = 2;
-		//[SerializeField]
-		//private int _south = 2;
 		RangeTileProviderOptions _rangeTileProviderOptions;
+		private bool _initialized = false;
 
 		public override void OnInitialized()
 		{
@@ -28,15 +21,16 @@ namespace Mapbox.Unity.Map
 				_rangeTileProviderOptions = new RangeTileProviderOptions();
 			}
 
-
-			//foreach (var tile in tilesToRequest)
-			//{
-			//	AddTile(tile);
-			//}
+			_initialized = true;
 		}
 
 		private void Update()
 		{
+			if (!_initialized)
+			{
+				return;
+			}
+
 			if (Options == null)
 			{
 				return;


### PR DESCRIPTION
**Related issue**

Closes #650 

**Description of changes**

Added a check to prevent NRE on tile update because map was not initialized. Added method to disable `InitializeOnStart` in the `Initialize With Location Provider` script. 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
