### PR TITLE
Fix incorrect editor culture handling on some locales

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -81,7 +81,8 @@
 					for (int i = 0; i < _features.Count; i++)
 					{
 						Feature feature = _features[i];
-						string coordinates = feature.Center.x + ", " + feature.Center.y;
+						string coordinates = feature.Center.x.ToString(CultureInfo.InvariantCulture) + ", " +
+						                     feature.Center.y.ToString(CultureInfo.InvariantCulture);
 						string buttonContent = feature.Address + " (" + coordinates + ")";
 
 						if (GUILayout.Button(buttonContent))


### PR DESCRIPTION
**Related issue**

Closes #658

**Description of changes**

Geocode coordinates are now converted with InvariantCulture, which makes sure they do not depend on the locale of the computer being used.

**Reviewers**

Tag your reviewer(s). Choose wisely.
