### PR TITLE
fix a bug in LayerPropertyIsEqualFilterComparer 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -263,7 +263,8 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 			}
 
 			var propertyValue = Convert.ToDouble(property);
-			if (propertyValue - Min < Mapbox.Utils.Constants.EpsilonFloatingPoint)
+			if (propertyValue > Min - Mapbox.Utils.Constants.EpsilonFloatingPoint && 
+				propertyValue < Min + Mapbox.Utils.Constants.EpsilonFloatingPoint)
 			{
 				return true;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Filters/TypeFilter.cs
@@ -263,8 +263,7 @@ namespace Mapbox.Unity.MeshGeneration.Filters
 			}
 
 			var propertyValue = Convert.ToDouble(property);
-			if (propertyValue > Min - Mapbox.Utils.Constants.EpsilonFloatingPoint && 
-				propertyValue < Min + Mapbox.Utils.Constants.EpsilonFloatingPoint)
+			if (Math.Abs(propertyValue - Min) < Mapbox.Utils.Constants.EpsilonFloatingPoint)
 			{
 				return true;
 			}


### PR DESCRIPTION
fix a bug in LayerPropertyIsEqualFilterComparer where it does <= instead of == (fixes #660)

Fixes #660

original code checks `if height - limit < e` which doesn't work when `limit > height` and left side value goes below zero.
Changed that with range check for upper and lower points of the range (limit +-e)

Your text here!

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
