### PR TITLE
fix a bug where SpawnInsideModifier getting stuck in infinite loop

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -23,6 +23,7 @@
 - Fix issue with Satellite TextureType.
 - Added a check to prevent NRE on tile update because map was not initialized.
 - Added method to disable `InitializeOnStart` in the `Initialize With Location Provider` script.
+- Fix loop counter in `SpawnInsidePrefabModifier` which was causing an infinite loop.
 
 ### v.1.4.0
 *03/20/2018*

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
@@ -90,8 +90,8 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 						transform.localScale = scale;
 					}
 
-					_spawnedCount++;
 				}
+				_spawnedCount++;
 			}
 		}
 


### PR DESCRIPTION
**Related issue**
Fixes #674 

**Description of changes**

Fixes wrong counter placement causing infinite loop for `SpawnInsidePrefabModifier` 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
