### PR TITLE
Add onUpdated event to the map.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -291,6 +291,7 @@ namespace Mapbox.Unity.Map
 			_worldRelativeScale = scale;
 		}
 		public event Action OnInitialized = delegate { };
+		public event Action OnUpdated = delegate { };
 
 		void Awake()
 		{
@@ -501,6 +502,11 @@ namespace Mapbox.Unity.Map
 				_mapScaleFactor = Vector3.one * Mathf.Pow(2, differenceInZoom);
 				_mapScaleFactor.y = 1;
 				Root.localScale = _mapScaleFactor;
+			}
+
+			if (OnUpdated != null)
+			{
+				OnUpdated();
 			}
 		}
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/DirectionsFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/DirectionsFactory.cs
@@ -40,11 +40,13 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			}
 			_directions = MapboxAccess.Instance.Directions;
 			_map.OnInitialized += Query;
+			_map.OnUpdated += Query;
 		}
 
 		void OnDestroy()
 		{
 			_map.OnInitialized -= Query;
+			_map.OnUpdated -= Query;
 		}
 
 		void Query()


### PR DESCRIPTION
 Fix Directions Factory to use the onUpdated event.

**Related issue**

Closes #689 

**Description of changes**

With the `UpdateMap` method added to the `AbstractMap` , we no longer can rely on `OnInitialized` event to trigger actions when the map's location is changed. Adding `OnUpdate` event will allow users to trigger custom actions when the map is updated. This  fix will make the Directions Factory example working again. 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

@BergWerkGIS @brnkhy 
