### PR TITLE
handle null response in geocode search window

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -31,6 +31,9 @@
   - Factories register to events in DataFetchers
 -  `Layer Name` , `Extrusion Property Name` and `Filter Key` are now selectable dropdowns indicating the layers and properties available in the current `Data Source`. Layers and properties no longer require manual string entry.
 
+#### Bug Fixes
+- Added checks to prevent NRE in `GeocodeAttributeSearchWindow` when searching with an invalid token or no connection.
+
 #### Known Issues
 - `Filters` with empty key or value parameters will exclude all features in a layer.
 
@@ -59,7 +62,6 @@
 - Added a check to prevent NRE on tile update because map was not initialized.
 - Added method to disable `InitializeOnStart` in the `Initialize With Location Provider` script.
 - Fix loop counter in `SpawnInsidePrefabModifier` which was causing an infinite loop.
-- Added checks to prevent NRE in `GeocodeAttributeSearchWindow` when searching with an invalid token or no connection.
 
 ### v.1.4.0
 *03/20/2018*

--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -59,6 +59,7 @@
 - Added a check to prevent NRE on tile update because map was not initialized.
 - Added method to disable `InitializeOnStart` in the `Initialize With Location Provider` script.
 - Fix loop counter in `SpawnInsidePrefabModifier` which was causing an infinite loop.
+- Added checks to prevent NRE in `GeocodeAttributeSearchWindow` when searching with an invalid token or no connection.
 
 ### v.1.4.0
 *03/20/2018*

--- a/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/GeocodeAttributeSearchWindow.cs
@@ -155,9 +155,14 @@
 
 		void HandleGeocoderResponse(ForwardGeocodeResponse res)
 		{
+			//null if no internet connection
 			if (res != null)
 			{
-				_features = res.Features;
+				//null if invalid token
+				if (res.Features != null)
+				{
+					_features = res.Features;
+				}
 			}
 			_isSearching = false;
 			this.Repaint();


### PR DESCRIPTION
**Description of changes**

While testing `AbstractMap` with an invalid token or no connection, I found the search window didn't handle these situations well. 

This fix addresses NREs when searching with no connection or a bad token.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
