### PR TITLE
fix #787 NauticalMiles unit is wrong

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/cheap-ruler-cs/CheapRuler.cs
+++ b/sdkproject/Assets/Mapbox/Core/cheap-ruler-cs/CheapRuler.cs
@@ -35,28 +35,28 @@
 			switch (outputUnits)
 			{
 				case CheapRulerUnits.Kilometers:
-					factor = 1;
+					factor = 1.0d;
 					break;
 				case CheapRulerUnits.Miles:
-					factor = 1000 / 1609.344;
+					factor = 1000.0d / 1609.344;
 					break;
 				case CheapRulerUnits.NauticalMiles:
-					factor = 1000 / 1852;
+					factor = 1000.0d / 1852.0d;
 					break;
 				case CheapRulerUnits.Meters:
-					factor = 1000;
+					factor = 1000.0d;
 					break;
 				case CheapRulerUnits.Yards:
-					factor = 1000 / 0.9144;
+					factor = 1000.0d / 0.9144;
 					break;
 				case CheapRulerUnits.Feet:
-					factor = 1000 / 0.3048;
+					factor = 1000.0d / 0.3048;
 					break;
 				case CheapRulerUnits.Inches:
-					factor = 1000 / 0.0254;
+					factor = 1000.0d / 0.0254;
 					break;
 				default:
-					factor = 1;
+					factor = 1.0d;
 					break;
 			}
 

--- a/sdkproject/Assets/Mapbox/Core/cheap-ruler-cs/Tests/Editor/MapboxUnitTests_CheapRulerCs.cs
+++ b/sdkproject/Assets/Mapbox/Core/cheap-ruler-cs/Tests/Editor/MapboxUnitTests_CheapRulerCs.cs
@@ -21,6 +21,11 @@ namespace Mapbox.CheapRulerCs.UnitTest
 	{
 
 
+		// TODO more tests ////////////////////
+		// see https://github.com/mapbox/cheap-ruler/blob/master/test/test.js
+		//////////////////////////
+
+
 		internal class point { public double x; public double y; }
 		internal class line
 		{
@@ -44,6 +49,8 @@ namespace Mapbox.CheapRulerCs.UnitTest
 			Assert.AreEqual(58, _lineFixtures.Count);
 		}
 
+
+
 		[Test]
 		public void DistanceInMiles()
 		{
@@ -53,9 +60,39 @@ namespace Mapbox.CheapRulerCs.UnitTest
 			double distKm = ruler.Distance(new double[] { 30.5, 32.8351 }, new double[] { 30.51, 32.8451 });
 			double distMiles = rulerMiles.Distance(new double[] { 30.5, 32.8351 }, new double[] { 30.51, 32.8451 });
 
+			Debug.LogFormat("{0} {1}", distKm, distMiles);
 			Assert.AreEqual(1.609344, distKm / distMiles, 1e-12, "wrong distance in miles");
 		}
 
+
+		[Test]
+		public void DistanceInNauticalMiles()
+		{
+			CheapRuler ruler = new CheapRuler(32.8351);
+			CheapRuler rulerMiles = new CheapRuler(32.8351, CheapRulerUnits.Miles);
+			CheapRuler rulerNauticalMiles = new CheapRuler(32.8351, CheapRulerUnits.NauticalMiles);
+
+			double distKm = ruler.Distance(new double[] { 30.5, 32.8351 }, new double[] { 30.51, 32.8451 });
+			double distMiles = rulerMiles.Distance(new double[] { 30.5, 32.8351 }, new double[] { 30.51, 32.8451 });
+			double distNauticalMiles = rulerNauticalMiles.Distance(new double[] { 30.5, 32.8351 }, new double[] { 30.51, 32.8451 });
+
+			Debug.LogFormat("{0} {1}", distKm, distNauticalMiles);
+			Assert.AreEqual(1.852, distKm / distNauticalMiles, 1e-12, "wrong distance km vs nautical miles");
+			Assert.AreEqual(1.15078, distMiles / distNauticalMiles, 1e-6, "wrong distance miles vs nautical miles");
+		}
+
+
+		[Test]
+		public void FromTile()
+		{
+			CheapRuler ruler1 = new CheapRuler(50.5);
+			CheapRuler ruler2 = CheapRuler.FromTile(11041, 15);
+
+			var p1 = new double[] { 30.5, 50.5 };
+			var p2 = new double[] { 30.51, 50.51 };
+
+			Assert.AreEqual(ruler1.Distance(p1, p2), ruler2.Distance(p1, p2), 3e-5, "CheapRuler.FromTile distance");
+		}
 
 
 


### PR DESCRIPTION
**Related issue**

ref #787 

**Description of changes**

Fix wrong results for nautical miles because of unwanted integer division.
Also add a test for calculation of nautical miles.

@atripathi-mb 