### PR TITLE
fix a bug where terrain data causing IndexOutOfRangeException

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -30,6 +30,7 @@
 - Added checks to prevent NRE in `GeocodeAttributeSearchWindow` when searching with an invalid token or no connection.
 - Fix issue where side wall mesh generation did not work with elevated terrain.
 - Fix issue with scaling prefabs for POI's. Enables correct scaling of objects with map.
+- Fix issue with data fetcher where it didn't handle failed connections properly and caused IndexOutOfRangeException 
 
 #### Known Issues
 - `Filters` with empty key or value parameters will exclude all features in a layer.

--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,10 +1,11 @@
-## CHANGELOG
+﻿## CHANGELOG
  ### v.1.4.3
 *??/??/2018*
 ##### New Features
 ##### Improvements
 ##### Bug Fixes
-- Fix issue with UvModifier where it calculates roof uv positions wrong
+- Fix issue with UvModifier which caused wrong roof uv positions calculations.
+- Fix issue with data fetcher to handle failed connections properly, which caused IndexOutOfRangeException during tile loading/unloading.
 
 
  ### v.1.4.2
@@ -38,7 +39,6 @@
 - Added checks to prevent NRE in `GeocodeAttributeSearchWindow` when searching with an invalid token or no connection.
 - Fix issue where side wall mesh generation did not work with elevated terrain.
 - Fix issue with scaling prefabs for POI's. Enables correct scaling of objects with map.
-- Fix issue with data fetcher where it didn't handle failed connections properly and caused IndexOutOfRangeException 
 
 ##### Known Issues
 - `Filters` with empty key or value parameters will exclude all features in a layer.

--- a/sdkproject/Assets/Mapbox/Unity/Editor/VectorSubLayerTreeView.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/VectorSubLayerTreeView.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e597f3da0a26e469584070315e18e4f1
+timeCreated: 1526503584
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
@@ -29,10 +29,11 @@ public class ImageDataFetcher : DataFetcher
 			if (rasterTile.HasError)
 			{
 				FetchingError(tile, new TileErrorEventArgs(tile.CanonicalTileId, rasterTile.GetType(), tile, rasterTile.Exceptions));
-				return;
 			}
-
-			DataRecieved(tile, rasterTile);
+			else
+			{
+				DataRecieved(tile, rasterTile);
+			}
 		});
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
@@ -22,7 +22,7 @@ public class TerrainDataFetcher : DataFetcher
 	public Action<UnityTile, TileErrorEventArgs> FetchingError = (t, s) => { };
 
 	//tile here should be totally optional and used only not to have keep a dictionary in terrain factory base
-	public void FetchTerrain(CanonicalTileId canonicalTileId, string mapid, UnityTile tile = null) 
+	public void FetchTerrain(CanonicalTileId canonicalTileId, string mapid, UnityTile tile = null)
 	{
 		var pngRasterTile = new RawPngRasterTile();
 		pngRasterTile.Initialize(_fileSource, canonicalTileId, mapid, () =>
@@ -31,8 +31,10 @@ public class TerrainDataFetcher : DataFetcher
 			{
 				FetchingError(tile, new TileErrorEventArgs(canonicalTileId, pngRasterTile.GetType(), null, pngRasterTile.Exceptions));
 			}
-
-			DataRecieved(tile, pngRasterTile);
+			else
+			{
+				DataRecieved(tile, pngRasterTile);
+			}
 		});
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
@@ -19,10 +19,11 @@ public class VectorDataFetcher : DataFetcher
 			{
 				FetchingError(tile, new TileErrorEventArgs(tile.CanonicalTileId, vectorTile.GetType(), tile, vectorTile.Exceptions));
 				tile.VectorDataState = TilePropertyState.Error;
-				return;
 			}
-
-			DataRecieved(tile, vectorTile);
+			else
+			{
+				DataRecieved(tile, vectorTile);
+			}
 		});
 	}
 }


### PR DESCRIPTION
 fix a bug where terrain data causing IndexOutOfRangeException because failed calls processed as successful.  fixes #785

change all ifelse clauses in data fetchers to be more clear and readable

**Description of changes**

If clause was wrong and success path was executed even when data fetching is failed.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

@atripathi-mb 
