### PR TITLE
2018 fix for coordinate parsing on systems with non 'en-US' locale

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -9,6 +9,7 @@ namespace Mapbox.Unity.Map
 	using Mapbox.Map;
 	using Mapbox.Unity.MeshGeneration.Factories;
 	using Mapbox.Unity.MeshGeneration.Data;
+	using System.Globalization;
 
 	public interface IUnifiedMap
 	{
@@ -495,7 +496,7 @@ namespace Mapbox.Unity.Map
 			{
 				_options = new MapOptions();
 			}
-			_options.locationOptions.latitudeLongitude = String.Format("{0},{1}", latLon.x, latLon.y);
+			_options.locationOptions.latitudeLongitude = String.Format(CultureInfo.InvariantCulture, "{0},{1}", latLon.x, latLon.y);
 			_options.locationOptions.zoom = zoom;
 
 			SetUpMap();


### PR DESCRIPTION
`Unity@2018` seems to have changed in a way that it takes operating system locale into consideration when `ToString()`ing floating point numbers.
This breaks all map instances where coordinates are parsed back to string for display.


@atripathi-mb 