### PR TITLE
Fix map snapping to ground.

### DIFF
--- a/sdkproject/Assets/MapboxAR/Unity/Ar/LerpAlignmentStrategy.cs
+++ b/sdkproject/Assets/MapboxAR/Unity/Ar/LerpAlignmentStrategy.cs
@@ -9,20 +9,27 @@ namespace Mapbox.Unity.Ar
 
 		Vector3 _targetPosition;
 		Quaternion _targetRotation = Quaternion.identity;
+		bool _isAlignmentAvailable = false;
 
 		public override void OnAlignmentAvailable(Alignment alignment)
 		{
 			_targetPosition = alignment.Position;
 			_targetRotation = Quaternion.Euler(0, alignment.Rotation, 0);
+			_isAlignmentAvailable = true;
 		}
 
 		// FIXME: this should be in a coroutine, which is activated in Align.
 		void Update()
 		{
-			var t = _followFactor * Time.deltaTime;
-			_transform.SetPositionAndRotation(
-				Vector3.Lerp(_transform.localPosition, _targetPosition, t),
-				Quaternion.Lerp(_transform.localRotation, _targetRotation, t));
+			if (_isAlignmentAvailable)
+			{
+				var t = _followFactor * Time.deltaTime;
+				_transform.SetPositionAndRotation(
+					Vector3.Lerp(_transform.localPosition, _targetPosition, t),
+					Quaternion.Lerp(_transform.localRotation, _targetRotation, t));
+				_isAlignmentAvailable = false;
+			}
+
 		}
 	}
 }

--- a/sdkproject/Assets/MapboxAR/Unity/Ar/SimpleAutomaticSynchronizationContextBehaviour.cs
+++ b/sdkproject/Assets/MapboxAR/Unity/Ar/SimpleAutomaticSynchronizationContextBehaviour.cs
@@ -175,7 +175,8 @@ namespace Mapbox.Unity.Ar
 						, "lightblue"
 					);
 
-					var position = Conversions.GeoToWorldPosition(latitudeLongitude, _map.CenterMercator, _map.WorldRelativeScale).ToVector3xz();
+					var position = _map.GeoToWorldPosition(latitudeLongitude, false);
+					position.y = _map.Root.position.y;
 					_synchronizationContext.AddSynchronizationNodes(location, position, _arPositionReference.localPosition);
 				}
 			}


### PR DESCRIPTION
Fixes WorldScale AR snap to ground not working for terrain with elevation. 
Solution works when `Snap Map to Zero` is turned on. 