### PR TITLE
fix for custom styles that go missing after building to any platform

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -6,7 +6,8 @@
 - Added 2 examples to the setup dialog 
 - AstronautGame - enhanced version of the Location Based game with custom styling and Astronaut asset
 - TrafficAndDirections - example built around using Mapbox's traffic data layer and directions API
-- Fixes the issue with Replacement Modifier to prevent duplicate prefab spawning and blocking wrong features. 
+- Fixes the issue with Replacement Modifier to prevent duplicate prefab spawning and blocking wrong features.
+- Fixes the issue with custom styles that go missing after building to a device.
 
 
 ### v.1.4.3

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -19,18 +19,6 @@
 			tooltip = "Map Id corresponding to the tileset."
 		};
 
-		string CustomSourceMapId
-		{
-			get
-			{
-				return EditorPrefs.GetString(objectId + "ImageryLayerProperties_customSourceMapId");
-			}
-			set
-			{
-				EditorPrefs.SetString(objectId + "ImageryLayerProperties_customSourceMapId", value);
-			}
-		}
-
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
@@ -78,9 +66,7 @@
 					GUI.enabled = true;
 					break;
 				case ImagerySourceType.Custom:
-					layerSourceId.stringValue = CustomSourceMapId;
 					EditorGUILayout.PropertyField(sourceOptionsProperty, new GUIContent { text = "Map Id / Style URL", tooltip = _mapIdGui.tooltip });
-					CustomSourceMapId = layerSourceId.stringValue;
 					break;
 				case ImagerySourceType.None:
 					break;


### PR DESCRIPTION
Simple fix. Test this by entering a custom style in the "Image" section
Build your map with custom style to a device. Go back to the editor and also check the UI.
The custom style you had entered should still show up in the editor UI.
The style should render properly on the device too. Let's verify this across a few different platforms
- [x] OSX
- [x] Android
- [x] iOS

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
