### PR TITLE
move tile material to map options

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/ElevationRequiredOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/ElevationRequiredOptions.cs
@@ -5,8 +5,6 @@
 	[Serializable]
 	public class ElevationRequiredOptions
 	{
-		[Tooltip("Unity material used for rendering terrain tiles.")]
-		public Material baseMaterial;
 		[Tooltip("Add Unity Physics collider to terrain tiles, used for detecting collisions etc.")]
 		public bool addCollider = false;
 		[Range(0, 100)]

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -11,5 +11,6 @@
 		public MapScalingOptions scalingOptions = new MapScalingOptions();
 		[Tooltip("Texture used while tiles are loading.")]
 		public Texture2D loadingTexture = null;
+		public Material tileMaterial = null;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -190,6 +190,7 @@
 				GUILayout.Space(-_lineHeight);
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("scalingOptions"));
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("loadingTexture"));
+				EditorGUILayout.PropertyField(property.FindPropertyRelative("tileMaterial"));
 			}
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationRequiredOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationRequiredOptionsDrawer.cs
@@ -13,7 +13,7 @@
 		{
 			EditorGUI.BeginProperty(position, label, property);
 
-			EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("baseMaterial"));
+			//EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("baseMaterial"));
 			position.y += lineHeight;
 			EditorGUI.PropertyField(new Rect(position.x, position.y, position.width, lineHeight), property.FindPropertyRelative("exaggerationFactor"));
 			position.y += lineHeight;

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -430,6 +430,11 @@ namespace Mapbox.Unity.Map
 				_mapVisualizer.SetLoadingTexture(Options.loadingTexture);
 			}
 
+			if (Options.tileMaterial != null)
+			{
+				_mapVisualizer.SetTileMaterial(Options.tileMaterial);
+			}
+
 			_mapVisualizer.Factories = new List<AbstractTileFactory>();
 			if (_terrain.IsLayerActive)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -27,6 +27,8 @@ namespace Mapbox.Unity.Map
 
 		[SerializeField]
 		Texture2D _loadingTexture;
+		[SerializeField]
+		Material TileMaterial;
 
 		protected IMapReadable _map;
 		protected Dictionary<UnwrappedTileId, UnityTile> _activeTiles = new Dictionary<UnwrappedTileId, UnityTile>();
@@ -58,6 +60,11 @@ namespace Mapbox.Unity.Map
 		public void SetLoadingTexture(Texture2D loadingTexture)
 		{
 			_loadingTexture = loadingTexture;
+		}
+
+		public void SetTileMaterial(Material tileMaterial)
+		{
+			TileMaterial = tileMaterial;
 		}
 
 		/// <summary>
@@ -186,6 +193,7 @@ namespace Mapbox.Unity.Map
 			if (unityTile == null)
 			{
 				unityTile = new GameObject().AddComponent<UnityTile>();
+				unityTile.MeshRenderer.material = TileMaterial;
 				unityTile.transform.SetParent(_map.Root, false);
 			}
 
@@ -244,5 +252,6 @@ namespace Mapbox.Unity.Map
 		}
 
 		protected abstract void PlaceTile(UnwrappedTileId tileId, UnityTile tile, IMapReadable map);
+
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/ElevatedTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/ElevatedTerrainStrategy.cs
@@ -44,11 +44,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				tile.gameObject.layer = _elevationOptions.unityLayerOptions.layerId;
 			}
 
-			if (tile.RasterDataState != Enums.TilePropertyState.Loaded)
-			{
-				tile.MeshRenderer.material = _elevationOptions.requiredOptions.baseMaterial;
-			}
-
 			if (tile.MeshFilter.mesh.vertexCount == 0)
 			{
 				CreateBaseMesh(tile);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/ElevatedTerrainWithSidesStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/ElevatedTerrainWithSidesStrategy.cs
@@ -45,19 +45,21 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				tile.gameObject.layer = _elevationOptions.unityLayerOptions.layerId;
 			}
 
-			if (tile.MeshRenderer == null)
+			if (tile.RasterDataState != Enums.TilePropertyState.Loaded)
 			{
-				var renderer = tile.gameObject.AddComponent<MeshRenderer>();
-				renderer.materials = new Material[2]
+				if (_elevationOptions.sideWallOptions.isActive)
 				{
-					_elevationOptions.requiredOptions.baseMaterial,
-					_elevationOptions.sideWallOptions.wallMaterial
-				};
+					var firstMat = tile.MeshRenderer.materials[0];
+					tile.MeshRenderer.materials = new Material[2]
+					{
+						firstMat,
+						_elevationOptions.sideWallOptions.wallMaterial
+					};
+				}
 			}
 
-			if (tile.MeshFilter == null)
+			if (tile.MeshFilter.mesh.vertexCount == 0)
 			{
-				tile.gameObject.AddComponent<MeshFilter>();
 				CreateBaseMesh(tile);
 			}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
@@ -23,12 +23,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 			{
 				tile.gameObject.layer = _elevationOptions.unityLayerOptions.layerId;
 			}
-
-			if (tile.RasterDataState != Enums.TilePropertyState.Loaded)
-			{
-				tile.MeshRenderer.material = _elevationOptions.requiredOptions.baseMaterial;
-			}
-
+			
 			GenerateTerrainMesh(tile);
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatTerrainStrategy.cs
@@ -26,15 +26,12 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 			{
 				if (_elevationOptions.sideWallOptions.isActive)
 				{
+					var firstMat = tile.MeshRenderer.materials[0];
 					tile.MeshRenderer.materials = new Material[2]
 					{
-						_elevationOptions.requiredOptions.baseMaterial,
+						firstMat,
 						_elevationOptions.sideWallOptions.wallMaterial
 					};
-				}
-				else
-				{
-					tile.MeshRenderer.material = _elevationOptions.requiredOptions.baseMaterial;
 				}
 			}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/LowPolyTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/LowPolyTerrainStrategy.cs
@@ -47,11 +47,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				tile.gameObject.layer = _elevationOptions.unityLayerOptions.layerId;
 			}
 
-			if (tile.RasterDataState != Enums.TilePropertyState.Loaded)
-			{
-				tile.MeshRenderer.material = _elevationOptions.requiredOptions.baseMaterial;
-			}
-
 			if (tile.MeshFilter.mesh.vertexCount == 0)
 			{
 				CreateBaseMesh(tile);

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -97,11 +97,6 @@
 			}
 		}
 
-		public void SetTerrainMaterial(Material baseMaterial)
-		{
-			_layerProperty.requiredOptions.baseMaterial = baseMaterial;
-		}
-
 		public void ShowSideWalls(float wallHeight, Material wallMaterial)
 		{
 			_layerProperty.sideWallOptions.isActive = true;


### PR DESCRIPTION
remove base material from ElevationRequiredOptions
add tile material to MapOptions
change MapManagerEditor to render tile material field in UI
remove material assignment from terrain strategies

this should fix the issue where imagery appeared lighter/darker on different tiles.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

cc @atripathi-mb 
