### PR TITLE
Improve query height method

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### v.1.4.6
+##### Bug Fixes
+- fix QueryHeight method to take tile local position/rotation/scale into account
+
 ### v.1.4.5
 08/20/2018
 ##### New Features


### PR DESCRIPTION
change GeoToWorldPosition in AbstractMap to take tile scale/position/rotation etc into account while calculating height

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

@atripathi-mb  @greglemonmapbox 