### PR TITLE
fix missing buildings on streets tileset

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,4 +1,7 @@
 ## CHANGELOG
+### v.1.4.5
+##### Bug Fixes
+- Fix an issue where streets tileset wasn't creating buildings on tile edges
 
 ### v.1.4.5
 08/20/2018

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -233,7 +233,23 @@
 			switch (sourceTypeValue)
 			{
 				case VectorSourceType.MapboxStreets:
+				{
+					var subLayerArray = layerProperty.FindPropertyRelative("vectorSubLayers");
+					for (int i = 0; i < subLayerArray.arraySize; i++)
+					{
+						var idsSetting = subLayerArray.GetArrayElementAtIndex(i).FindPropertyRelative("buildingsWithUniqueIds");
+						idsSetting.boolValue = false;
+					}
+					break;
+				}
 				case VectorSourceType.MapboxStreetsWithBuildingIds:
+				{
+					var subLayerArray = layerProperty.FindPropertyRelative("vectorSubLayers");
+					for (int i = 0; i < subLayerArray.arraySize; i++)
+					{
+						var idsSetting = subLayerArray.GetArrayElementAtIndex(i).FindPropertyRelative("buildingsWithUniqueIds");
+						idsSetting.boolValue = true;
+					}
 					var sourcePropertyValue = MapboxDefaultVector.GetParameters(sourceTypeValue);
 					layerSourceId.stringValue = sourcePropertyValue.Id;
 					GUI.enabled = false;
@@ -241,6 +257,7 @@
 					GUI.enabled = true;
 					isActiveProperty.boolValue = true;
 					break;
+				}
 				case VectorSourceType.Custom:
 					EditorGUILayout.PropertyField(layerSourceProperty, mapIdGui);
 					isActiveProperty.boolValue = true;


### PR DESCRIPTION
system wasn't rendering buildings on the edge of the tile when streets tileset selected and "buildings with ids" boolean set to true. and that checkbox isn't drawn on streets.

I changed editor script to set `buildingsWithUniqueIds` bool to true/false on all layers on data source switch.
I'm not sure my editor code is correct though.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

@atripathi-mb @greglemonmapbox 
