### PR TITLE
Fix buildingid setting

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,13 +1,13 @@
 ## CHANGELOG
+
 ### v.1.4.6
+??/??/2018
 ##### Improvements
 - Terrain mesh is generated as flat on height data errors
 ##### Bug Fixes
 - Fix issue with building side wall modifier where it miscalculated the floor heights causing overlaping polygons/floors
-
-### v.1.4.6
-##### Bug Fixes
-- fix QueryHeight method to take tile local position/rotation/scale into account
+- Fix an issue where streets tileset wasn't creating buildings on tile edges
+- Fix QueryHeight method to take tile local position/rotation/scale into account
 
 ### v.1.4.5
 08/20/2018

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
@@ -28,16 +28,13 @@
 			if (showGameplay)
 			{
 
+				bool isPrimitiveTypeValidForBuidingIds = (primitiveTypeProp == VectorPrimitiveType.Polygon || primitiveTypeProp == VectorPrimitiveType.Custom);
+				bool isSourceValidForBuildingIds = sourceType != VectorSourceType.MapboxStreets;
 
-				if (!(primitiveTypeProp != VectorPrimitiveType.Point && primitiveTypeProp != VectorPrimitiveType.Custom))
+				layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue = isPrimitiveTypeValidForBuidingIds && isSourceValidForBuildingIds;
+
+				if (layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue == true)
 				{
-					layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue = false;
-				}
-
-
-				if ((primitiveTypeProp == VectorPrimitiveType.Polygon || primitiveTypeProp == VectorPrimitiveType.Custom) && sourceType != VectorSourceType.MapboxStreets)
-				{
-					layerProperty.FindPropertyRelative("honorBuildingIdSetting").boolValue = true;
 					EditorGUILayout.PropertyField(layerProperty.FindPropertyRelative("buildingsWithUniqueIds"), new GUIContent
 					{
 						text = "Buildings With Unique Ids",

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -100,7 +100,16 @@
 			{
 				//if its of type prefabitemoptions then separate the visualizer type
 				LayerVisualizerBase visualizer = CreateInstance<VectorLayerVisualizer>();
-				((VectorLayerVisualizer) visualizer).SetProperties(sublayer);
+
+				// Set honorBuildingSettings - need to set here in addition to the UI. 
+				// Not setting it here can lead to wrong filtering. 
+
+				bool isPrimitiveTypeValidForBuidingIds = (sublayer.coreOptions.geometryType == VectorPrimitiveType.Polygon || sublayer.coreOptions.geometryType == VectorPrimitiveType.Custom);
+				bool isSourceValidForBuildingIds = (_properties.sourceType != VectorSourceType.MapboxStreets);
+
+				sublayer.honorBuildingIdSetting = isPrimitiveTypeValidForBuidingIds && isSourceValidForBuildingIds;
+				// Setup visualizer. 
+				((VectorLayerVisualizer)visualizer).SetProperties(sublayer);
 
 				visualizer.Initialize();
 				if (visualizer == null)
@@ -114,11 +123,11 @@
 				}
 				else
 				{
-					_layerBuilder.Add(visualizer.Key, new List<LayerVisualizerBase>() {visualizer});
+					_layerBuilder.Add(visualizer.Key, new List<LayerVisualizerBase>() { visualizer });
 				}
 			}
 		}
-		
+
 		public override void SetOptions(LayerProperties options)
 		{
 			_properties = (VectorLayerProperties)options;


### PR DESCRIPTION
**Description of changes**

Fixes `buildingsWithUniqueIds` setting being applied to streets dataset and filtering out buildings. 

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
@brnkhy 