### PR TITLE
Fix tabletop ar snap to plane

### DIFF
--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/ARTableTopCameraMovement.cs
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/ARTableTopCameraMovement.cs
@@ -106,7 +106,10 @@
 		{
 			var zoom = Mathf.Max(0.0f, Mathf.Min(_mapManager.Zoom + zoomFactor * _zoomSpeed, 21.0f));
 
-			_mapManager.UpdateMap(_mapManager.CenterLatitudeLongitude, zoom);
+			if (Math.Abs(zoom - _mapManager.Zoom) > 0.0f)
+			{
+				_mapManager.UpdateMap(_mapManager.CenterLatitudeLongitude, zoom);
+			}
 		}
 
 		void PanMapUsingKeyBoard(float xMove, float zMove)

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Mapbox.Unity.Map;
+
+public class SnapMapToTargetTransform : MonoBehaviour
+{
+	[SerializeField]
+	private AbstractMap _map;
+	[SerializeField]
+	private Transform _target;
+
+	private void Awake()
+	{
+		if (_map == null)
+		{
+			_map = FindObjectOfType<AbstractMap>();
+		}
+	}
+
+	// Use this for initialization
+	void Start()
+	{
+		_map.OnUpdated += SnapMapToTarget;
+	}
+
+	void SnapMapToTarget()
+	{
+		var h = _map.QueryElevationInUnityUnitsAt(_map.CenterLatitudeLongitude);
+		_map.Root.transform.position = new Vector3(
+			 _map.Root.transform.position.x,
+			  _target.transform.position.y - h,
+			 _map.Root.transform.position.z);
+	}
+}

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs.meta
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs.meta
@@ -1,5 +1,7 @@
 fileFormatVersion: 2
-guid: 7e6bd4b305d8f4e57b373706b0c82989
+guid: 4a0def3e793b744849a7bd42ac59a338
+timeCreated: 1539027390
+licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs.meta
+++ b/sdkproject/Assets/MapboxAR/Examples/ARTabletop/Scripts/SnapMapToTargetTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e6bd4b305d8f4e57b373706b0c82989
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/MapboxAR/Examples/Scenes/TabletopAR.unity
+++ b/sdkproject/Assets/MapboxAR/Examples/Scenes/TabletopAR.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,7 +39,6 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
-  m_UseRadianceAmbientProbe: 0
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -55,10 +54,11 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 9
     m_Resolution: 1
     m_BakeResolution: 50
-    m_AtlasSize: 1024
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
     m_AO: 1
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -218,47 +218,47 @@ Prefab:
     - target: {fileID: 224907993215804030, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224907993215804030, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 116.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -95.73414
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 171.46828
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 191.46828
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114603753021256032, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -291,27 +291,32 @@ Prefab:
     - target: {fileID: 224907856650798614, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224907856650798614, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224907856650798614, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: -17
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
-  m_IsPrefabAsset: 0
+  m_ParentPrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &312429107 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4324505364571932, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+    type: 2}
+  m_PrefabInternal: {fileID: 2141252174}
 --- !u!1 &673908967
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 6
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 673908970}
   - component: {fileID: 673908969}
@@ -326,7 +331,7 @@ GameObject:
 --- !u!114 &673908968
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 673908967}
   m_Enabled: 1
@@ -344,7 +349,7 @@ MonoBehaviour:
 --- !u!114 &673908969
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 673908967}
   m_Enabled: 1
@@ -358,7 +363,7 @@ MonoBehaviour:
 --- !u!4 &673908970
 Transform:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 673908967}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -368,35 +373,30 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &715403070 stripped
+--- !u!1 &790379535 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1752371506266588, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+  m_PrefabParentObject: {fileID: 1752371506266588, guid: c0ce4c9dacbd84ff09f18011abded7e6,
     type: 2}
   m_PrefabInternal: {fileID: 2141252174}
---- !u!114 &715403073 stripped
+--- !u!114 &790379538 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+  m_PrefabParentObject: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
     type: 2}
   m_PrefabInternal: {fileID: 2141252174}
   m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
---- !u!114 &715403074
+--- !u!114 &790379539
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 715403070}
+  m_GameObject: {fileID: 790379535}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7e6bd4b305d8f4e57b373706b0c82989, type: 3}
+  m_Script: {fileID: 11500000, guid: 4a0def3e793b744849a7bd42ac59a338, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _map: {fileID: 715403073}
-  _target: {fileID: 1430279304}
---- !u!4 &1430279304 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4324505364571932, guid: c0ce4c9dacbd84ff09f18011abded7e6,
-    type: 2}
-  m_PrefabInternal: {fileID: 2141252174}
+  _map: {fileID: 790379538}
+  _target: {fileID: 312429107}
 --- !u!1001 &2141252174
 Prefab:
   m_ObjectHideFlags: 0
@@ -466,30 +466,11 @@ Prefab:
       propertyPath: _options.extentOptions.extentType
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 114818216676110696, guid: c0ce4c9dacbd84ff09f18011abded7e6,
-        type: 2}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
         type: 2}
       propertyPath: _terrain._layerProperty.elevationLayerType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114282370371282284, guid: c0ce4c9dacbd84ff09f18011abded7e6,
-        type: 2}
-      propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
-        type: 2}
-      propertyPath: _options.placementOptions.snapMapToZero
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4694041931287344, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
-  m_IsPrefabAsset: 0
+  m_ParentPrefab: {fileID: 100100000, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
+  m_IsPrefabParent: 0

--- a/sdkproject/Assets/MapboxAR/Examples/Scenes/TabletopAR.unity
+++ b/sdkproject/Assets/MapboxAR/Examples/Scenes/TabletopAR.unity
@@ -213,7 +213,7 @@ Prefab:
     - target: {fileID: 224907993215804030, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchorMin.y
-      value: 0.12569892
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224907993215804030, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -243,7 +243,7 @@ Prefab:
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -114.37708
+      value: -95.73414
       objectReference: {fileID: 0}
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -253,12 +253,12 @@ Prefab:
     - target: {fileID: 224835413515161394, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 208.75417
+      value: 171.46828
       objectReference: {fileID: 0}
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 228.75417
+      value: 191.46828
       objectReference: {fileID: 0}
     - target: {fileID: 114603753021256032, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -281,7 +281,7 @@ Prefab:
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000015258789
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114731470950229392, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -368,6 +368,35 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &715403070 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1752371506266588, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+    type: 2}
+  m_PrefabInternal: {fileID: 2141252174}
+--- !u!114 &715403073 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+    type: 2}
+  m_PrefabInternal: {fileID: 2141252174}
+  m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
+--- !u!114 &715403074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 715403070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e6bd4b305d8f4e57b373706b0c82989, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _map: {fileID: 715403073}
+  _target: {fileID: 1430279304}
+--- !u!4 &1430279304 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4324505364571932, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+    type: 2}
+  m_PrefabInternal: {fileID: 2141252174}
 --- !u!1001 &2141252174
 Prefab:
   m_ObjectHideFlags: 0
@@ -440,6 +469,25 @@ Prefab:
     - target: {fileID: 114818216676110696, guid: c0ce4c9dacbd84ff09f18011abded7e6,
         type: 2}
       propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _terrain._layerProperty.elevationLayerType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114282370371282284, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _options.placementOptions.snapMapToZero
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4694041931287344, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
+      propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/sdkproject/Assets/MapboxAR/Examples/Scenes/WorldScaleAR.unity
+++ b/sdkproject/Assets/MapboxAR/Examples/Scenes/WorldScaleAR.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,7 +39,6 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
-  m_UseRadianceAmbientProbe: 0
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -55,10 +54,11 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 9
     m_Resolution: 1
     m_BakeResolution: 50
-    m_AtlasSize: 1024
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
     m_AO: 1
     m_AOMaxDistance: 1
     m_CompAOExponent: 1

--- a/sdkproject/Assets/MapboxAR/Materials.meta
+++ b/sdkproject/Assets/MapboxAR/Materials.meta
@@ -4,6 +4,7 @@ folderAsset: yes
 timeCreated: 1501256004
 licenseType: Pro
 DefaultImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/sdkproject/Assets/MapboxAR/Prefabs.meta
+++ b/sdkproject/Assets/MapboxAR/Prefabs.meta
@@ -4,6 +4,7 @@ folderAsset: yes
 timeCreated: 1501166183
 licenseType: Pro
 DefaultImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/sdkproject/Assets/MapboxAR/Textures.meta
+++ b/sdkproject/Assets/MapboxAR/Textures.meta
@@ -4,6 +4,7 @@ folderAsset: yes
 timeCreated: 1501349098
 licenseType: Pro
 DefaultImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
**Related issue**

 Closes #807 

**Description of changes**

Add a script to place map back on the AR plane after zoom is changed. 

To test - 
1. Open TableTopAR scene
2. Under Terrain section , change `ElevationType` to Terrain With Elevation.
3. zoom in/out -> map should remain on the AR Plane. 

To see the previous behavior, turn off the SnapMapToTargetTransform script and repeat steps above


**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
@jordy-isaac @brnkhy 