### PR TITLE
Terrain section event refactor apply property changes at end of gui

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxDataProperty.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxDataProperty.cs
@@ -11,7 +11,6 @@
 				handler(this, e);
 			}
 		}
-		bool _hasChanged = false;
 		public bool HasChanged
 		{
 			set
@@ -19,8 +18,6 @@
 				if (value == true)
 				{
 					OnPropertyHasChanged(null /*Pass args here */);
-					// reset HasChanged 
-					_hasChanged = false;
 				}
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -14,6 +14,14 @@
 	/// </summary>
 	public static class EditorHelper
 	{
+		public static void CheckForModifiedProperty<T>(SerializedProperty property, T targetObject)
+		{
+			MapboxDataProperty targetObjectAsDataProperty = targetObject as MapboxDataProperty;
+			if (property.serializedObject.ApplyModifiedProperties() && targetObjectAsDataProperty != null)
+			{
+				targetObjectAsDataProperty.HasChanged = true;
+			}
+		}
 
 		public static void CheckForModifiedProperty(SerializedProperty property)
 		{

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -25,11 +25,7 @@
 
 		public static void CheckForModifiedProperty(SerializedProperty property)
 		{
-			MapboxDataProperty targetObjectAsDataProperty = GetTargetObjectOfProperty(property) as MapboxDataProperty;
-			if (property.serializedObject.ApplyModifiedProperties() && targetObjectAsDataProperty != null)
-			{
-				targetObjectAsDataProperty.HasChanged = true;
-			}
+			CheckForModifiedProperty(property, GetTargetObjectOfProperty(property));
 		}
 
 		public static IEnumerable<SerializedProperty> GetChildren(this SerializedProperty property)

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -15,9 +15,9 @@
 	public static class EditorHelper
 	{
 
-		public static void CheckForModifiedProperty<T>(SerializedProperty property, T targetObject)
+		public static void CheckForModifiedProperty(SerializedProperty property)
 		{
-			MapboxDataProperty targetObjectAsDataProperty = targetObject as MapboxDataProperty;
+			MapboxDataProperty targetObjectAsDataProperty = GetTargetObjectOfProperty(property) as MapboxDataProperty;
 			if (property.serializedObject.ApplyModifiedProperties() && targetObjectAsDataProperty != null)
 			{
 				targetObjectAsDataProperty.HasChanged = true;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -45,8 +45,6 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			property.serializedObject.Update();
-
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
 
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");
@@ -69,7 +67,6 @@
 			var sourceTypeLabel = new GUIContent { text = "Data Source", tooltip = "Source tileset for Terrain." };
 
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
-			EditorHelper.CheckForModifiedProperty(property);
 
 			var sourceTypeValue = (ElevationSourceType)sourceTypeProperty.enumValueIndex;
 
@@ -103,7 +100,6 @@
 			}
 
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("elevationLayerType"), new GUIContent { text = elevationLayerType.displayName, tooltip = ((ElevationLayerType)elevationLayerType.enumValueIndex).Description() });
-			EditorHelper.CheckForModifiedProperty(property);
 
 			if (sourceTypeValue == ElevationSourceType.None)
 			{
@@ -113,22 +109,19 @@
 			GUILayout.Space(-lineHeight);
 
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("requiredOptions"), true);
-			EditorHelper.CheckForModifiedProperty(property);
 
 			ShowPosition = EditorGUILayout.Foldout(ShowPosition, "Others");
-			property.serializedObject.ApplyModifiedProperties();
+
 			if (ShowPosition)
 			{
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("modificationOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("sideWallOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("unityLayerOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property);
 			}
-			property.serializedObject.ApplyModifiedProperties();
+
+			EditorHelper.CheckForModifiedProperty(property);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -45,6 +45,8 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
+			property.serializedObject.Update();
+
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
 
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -152,8 +152,6 @@
 					EditorHelper.CheckForModifiedProperty(property);
 				}
 			}
-
-			EditorHelper.CheckForModifiedProperty(property);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -68,13 +68,21 @@
 			}
 			var sourceTypeLabel = new GUIContent { text = "Data Source", tooltip = "Source tileset for Terrain." };
 
+			EditorGUI.BeginChangeCheck();
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
 
 			var sourceTypeValue = (ElevationSourceType)sourceTypeProperty.enumValueIndex;
 
 			var sourceOptionsProperty = property.FindPropertyRelative("sourceOptions");
 			var layerSourceProperty = sourceOptionsProperty.FindPropertyRelative("layerSource");
 			var layerSourceId = layerSourceProperty.FindPropertyRelative("Id");
+
+			EditorGUI.BeginChangeCheck();
+
 			switch (sourceTypeValue)
 			{
 				case ElevationSourceType.MapboxTerrain:
@@ -93,6 +101,11 @@
 					break;
 			}
 
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
+
 			var elevationLayerType = property.FindPropertyRelative("elevationLayerType");
 
 			if (sourceTypeValue == ElevationSourceType.None)
@@ -101,7 +114,12 @@
 				elevationLayerType.enumValueIndex = (int)ElevationLayerType.FlatTerrain;
 			}
 
+			EditorGUI.BeginChangeCheck();
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("elevationLayerType"), new GUIContent { text = elevationLayerType.displayName, tooltip = ((ElevationLayerType)elevationLayerType.enumValueIndex).Description() });
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
 
 			if (sourceTypeValue == ElevationSourceType.None)
 			{
@@ -110,17 +128,29 @@
 
 			GUILayout.Space(-lineHeight);
 
+			EditorGUI.BeginChangeCheck();
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("requiredOptions"), true);
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
 
 			ShowPosition = EditorGUILayout.Foldout(ShowPosition, "Others");
 
 			if (ShowPosition)
 			{
+				EditorGUI.BeginChangeCheck();
+				         
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("modificationOptions"), true);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("sideWallOptions"), true);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("unityLayerOptions"), true);
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					EditorHelper.CheckForModifiedProperty(property);
+				}
 			}
 
 			EditorHelper.CheckForModifiedProperty(property);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -46,7 +46,6 @@
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			property.serializedObject.Update();
-			ElevationLayerProperties elevationLayerProperties = (ElevationLayerProperties)EditorHelper.GetTargetObjectOfProperty(property);
 
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
 
@@ -70,7 +69,7 @@
 			var sourceTypeLabel = new GUIContent { text = "Data Source", tooltip = "Source tileset for Terrain." };
 
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
-			EditorHelper.CheckForModifiedProperty(sourceTypeProperty, elevationLayerProperties);
+			EditorHelper.CheckForModifiedProperty(property);
 
 			var sourceTypeValue = (ElevationSourceType)sourceTypeProperty.enumValueIndex;
 
@@ -104,7 +103,7 @@
 			}
 
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("elevationLayerType"), new GUIContent { text = elevationLayerType.displayName, tooltip = ((ElevationLayerType)elevationLayerType.enumValueIndex).Description() });
-			EditorHelper.CheckForModifiedProperty(elevationLayerType, elevationLayerProperties);
+			EditorHelper.CheckForModifiedProperty(property);
 
 			if (sourceTypeValue == ElevationSourceType.None)
 			{
@@ -114,20 +113,20 @@
 			GUILayout.Space(-lineHeight);
 
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("requiredOptions"), true);
-			EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("requiredOptions"), elevationLayerProperties);
+			EditorHelper.CheckForModifiedProperty(property);
 
 			ShowPosition = EditorGUILayout.Foldout(ShowPosition, "Others");
 			property.serializedObject.ApplyModifiedProperties();
 			if (ShowPosition)
 			{
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("modificationOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("modificationOptions"), elevationLayerProperties);
+				EditorHelper.CheckForModifiedProperty(property);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("sideWallOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("sideWallOptions"), elevationLayerProperties);
+				EditorHelper.CheckForModifiedProperty(property);
 
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("unityLayerOptions"), true);
-				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("unityLayerOptions"), elevationLayerProperties);
+				EditorHelper.CheckForModifiedProperty(property);
 			}
 			property.serializedObject.ApplyModifiedProperties();
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -45,6 +45,7 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
+			property.serializedObject.Update();
 			ElevationLayerProperties elevationLayerProperties = (ElevationLayerProperties)EditorHelper.GetTargetObjectOfProperty(property);
 
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
@@ -68,14 +69,8 @@
 			}
 			var sourceTypeLabel = new GUIContent { text = "Data Source", tooltip = "Source tileset for Terrain." };
 
-			// sourceTypeCacheValue = sourceTypeProperty.enumValueIndex;
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
 			EditorHelper.CheckForModifiedProperty(sourceTypeProperty, elevationLayerProperties);
-
-			//if(sourceTypeProperty.enumValueIndex != sourceTypeCacheValue && elevationLayerProperties != null)
-			//{
-			//	elevationLayerProperties.HasChanged = true;
-			//}
 
 			var sourceTypeValue = (ElevationSourceType)sourceTypeProperty.enumValueIndex;
 
@@ -108,13 +103,8 @@
 				elevationLayerType.enumValueIndex = (int)ElevationLayerType.FlatTerrain;
 			}
 
-			//int cachedElevationLayerType = elevationLayerType.enumValueIndex;
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("elevationLayerType"), new GUIContent { text = elevationLayerType.displayName, tooltip = ((ElevationLayerType)elevationLayerType.enumValueIndex).Description() });
 			EditorHelper.CheckForModifiedProperty(elevationLayerType, elevationLayerProperties);
-			//if (elevationLayerType.enumValueIndex != cachedElevationLayerType && elevationLayerProperties != null)
-			//{
-			//	elevationLayerProperties.HasChanged = true;
-			//}
 
 			if (sourceTypeValue == ElevationSourceType.None)
 			{
@@ -123,25 +113,23 @@
 
 			GUILayout.Space(-lineHeight);
 
-			EditorGUI.BeginChangeCheck();
 			EditorGUILayout.PropertyField(property.FindPropertyRelative("requiredOptions"), true);
-			if (EditorGUI.EndChangeCheck() && elevationLayerProperties != null)
-			{
-				elevationLayerProperties.HasChanged = true;
-			}
+			EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("requiredOptions"), elevationLayerProperties);
 
 			ShowPosition = EditorGUILayout.Foldout(ShowPosition, "Others");
+			property.serializedObject.ApplyModifiedProperties();
 			if (ShowPosition)
 			{
-				EditorGUI.BeginChangeCheck();
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("modificationOptions"), true);
+				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("modificationOptions"), elevationLayerProperties);
+
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("sideWallOptions"), true);
+				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("sideWallOptions"), elevationLayerProperties);
+
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("unityLayerOptions"), true);
-				if (EditorGUI.EndChangeCheck() && elevationLayerProperties != null)
-				{
-					elevationLayerProperties.HasChanged = true;
-				}
+				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("unityLayerOptions"), elevationLayerProperties);
 			}
+			property.serializedObject.ApplyModifiedProperties();
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -43,13 +43,19 @@
 			// Draw label.
 			var sourceTypeLabel = new GUIContent { text = "Data Source", tooltip = "Source tileset for Imagery." };
 
+			EditorGUI.BeginChangeCheck();
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
-
+			if(EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
 			sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 
 			var sourceOptionsProperty = property.FindPropertyRelative("sourceOptions");
 			var layerSourceProperty = sourceOptionsProperty.FindPropertyRelative("layerSource");
 			var layerSourceId = layerSourceProperty.FindPropertyRelative("Id");
+
+			EditorGUI.BeginChangeCheck();
 
 			switch (sourceTypeValue)
 			{
@@ -74,9 +80,19 @@
 					break;
 			}
 
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorHelper.CheckForModifiedProperty(property);
+			}
+
 			if (sourceTypeValue != ImagerySourceType.None)
 			{
+				EditorGUI.BeginChangeCheck();
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("rasterOptions"));
+				if (EditorGUI.EndChangeCheck())
+				{
+					EditorHelper.CheckForModifiedProperty(property);
+				}
 			}
 
 			EditorHelper.CheckForModifiedProperty(property);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -94,8 +94,6 @@
 					EditorHelper.CheckForModifiedProperty(property);
 				}
 			}
-
-			EditorHelper.CheckForModifiedProperty(property);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -79,13 +79,13 @@
 			if (sourceTypeValue != ImagerySourceType.None)
 			{
 				EditorGUI.BeginChangeCheck();
-				EditorGUI.BeginChangeCheck();
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("rasterOptions"));
-				if(EditorGUI.EndChangeCheck())
+				if(EditorGUI.EndChangeCheck() && imageryLayerProperties != null)
 				{
 					imageryLayerProperties.HasChanged = true;
 				}
 			}
+			property.serializedObject.ApplyModifiedProperties();
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -23,8 +23,6 @@
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");
 			var sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 
-			ImageryLayerProperties imageryLayerProperties = (ImageryLayerProperties)EditorHelper.GetTargetObjectOfProperty(property);
-
 			var displayNames = sourceTypeProperty.enumDisplayNames;
 			int count = sourceTypeProperty.enumDisplayNames.Length;
 			if (!isGUIContentSet)
@@ -48,7 +46,7 @@
 
 			sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 
-			EditorHelper.CheckForModifiedProperty(sourceTypeProperty, imageryLayerProperties);
+			EditorHelper.CheckForModifiedProperty(property);
 
 			var sourceOptionsProperty = property.FindPropertyRelative("sourceOptions");
 			var layerSourceProperty = sourceOptionsProperty.FindPropertyRelative("layerSource");
@@ -80,7 +78,7 @@
 			if (sourceTypeValue != ImagerySourceType.None)
 			{
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("rasterOptions"));
-				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("rasterOptions"), imageryLayerProperties);
+				EditorHelper.CheckForModifiedProperty(property);
 			}
 			property.serializedObject.ApplyModifiedProperties();
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -19,6 +19,7 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
+			property.serializedObject.Update();
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");
 			var sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 
@@ -75,15 +76,11 @@
 				default:
 					break;
 			}
-
+			property.serializedObject.ApplyModifiedProperties();
 			if (sourceTypeValue != ImagerySourceType.None)
 			{
-				EditorGUI.BeginChangeCheck();
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("rasterOptions"));
-				if(EditorGUI.EndChangeCheck() && imageryLayerProperties != null)
-				{
-					imageryLayerProperties.HasChanged = true;
-				}
+				EditorHelper.CheckForModifiedProperty(property.FindPropertyRelative("rasterOptions"), imageryLayerProperties);
 			}
 			property.serializedObject.ApplyModifiedProperties();
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -19,7 +19,6 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			property.serializedObject.Update();
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");
 			var sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 
@@ -45,8 +44,6 @@
 			sourceTypeProperty.enumValueIndex = EditorGUILayout.Popup(sourceTypeLabel, sourceTypeProperty.enumValueIndex, sourceTypeContent);
 
 			sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
-
-			EditorHelper.CheckForModifiedProperty(property);
 
 			var sourceOptionsProperty = property.FindPropertyRelative("sourceOptions");
 			var layerSourceProperty = sourceOptionsProperty.FindPropertyRelative("layerSource");
@@ -74,13 +71,13 @@
 				default:
 					break;
 			}
-			property.serializedObject.ApplyModifiedProperties();
+
 			if (sourceTypeValue != ImagerySourceType.None)
 			{
 				EditorGUILayout.PropertyField(property.FindPropertyRelative("rasterOptions"));
-				EditorHelper.CheckForModifiedProperty(property);
 			}
-			property.serializedObject.ApplyModifiedProperties();
+
+			EditorHelper.CheckForModifiedProperty(property);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -19,6 +19,8 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
+			property.serializedObject.Update();
+
 			var sourceTypeProperty = property.FindPropertyRelative("sourceType");
 			var sourceTypeValue = (ImagerySourceType)sourceTypeProperty.enumValueIndex;
 

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/ElevationLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/ElevationLayerProperties.cs
@@ -7,16 +7,6 @@
 	[Serializable]
 	public class ElevationLayerProperties : LayerProperties
 	{
-		public event Action OnPropertyUpdated = delegate { };
-
-		public void UpdateProperty()
-		{
-			if (OnPropertyUpdated != null)
-			{
-				OnPropertyUpdated();
-			}
-		}
-
 		public ElevationSourceType sourceType = ElevationSourceType.MapboxTerrain;
 
 		public LayerSourceOptions sourceOptions = new LayerSourceOptions()
@@ -29,6 +19,9 @@
 		};
 		public ElevationLayerType elevationLayerType = ElevationLayerType.FlatTerrain;
 		public ElevationRequiredOptions requiredOptions = new ElevationRequiredOptions();
+		//{
+
+		//}
 		public ElevationModificationOptions modificationOptions = new ElevationModificationOptions();
 		public UnityLayerOptions unityLayerOptions = new UnityLayerOptions();
 		public TerrainSideWallOptions sideWallOptions = new TerrainSideWallOptions();

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/ElevationLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/ElevationLayerProperties.cs
@@ -19,9 +19,6 @@
 		};
 		public ElevationLayerType elevationLayerType = ElevationLayerType.FlatTerrain;
 		public ElevationRequiredOptions requiredOptions = new ElevationRequiredOptions();
-		//{
-
-		//}
 		public ElevationModificationOptions modificationOptions = new ElevationModificationOptions();
 		public UnityLayerOptions unityLayerOptions = new UnityLayerOptions();
 		public TerrainSideWallOptions sideWallOptions = new TerrainSideWallOptions();

--- a/sdkproject/Assets/Mapbox/Unity/LayerProperties/ImageryLayerProperties.cs
+++ b/sdkproject/Assets/Mapbox/Unity/LayerProperties/ImageryLayerProperties.cs
@@ -7,23 +7,7 @@
 	[System.Serializable]
 	public class ImageryLayerProperties : LayerProperties
 	{
-		public event Action OnPropertyUpdated = delegate { };
-
-		public void UpdateProperty()
-		{
-			if (OnPropertyUpdated != null)
-			{
-				OnPropertyUpdated();
-			}
-		}
-
-		//[TestAttribute]
 		public ImagerySourceType sourceType = ImagerySourceType.MapboxStreets;
-
-		//[StyleSearch]
-		// TODO : Do we really need a separate DS for default styles ??
-		// Style struct should be enough to hold all tile-service info?
-		//public Style CustomStyle = new Style();
 
 		public LayerSourceOptions sourceOptions = new LayerSourceOptions()
 		{

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -521,7 +521,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
-					Debug.Log("<color=red>_imagery.UpdateLayer</color>");
+					Debug.Log("<color=red>Image</color>");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{
@@ -538,7 +538,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
-					Debug.Log("<color=green>_terrain.UpdateLayer</color>");
+					Debug.Log("<color=green>Terrain</color>");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -521,7 +521,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
-					Debug.Log("_imagery.UpdateLayer");
+					Debug.Log("<color=red>_imagery.UpdateLayer</color>");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{
@@ -538,7 +538,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
-					Debug.Log("_terrain.UpdateLayer");
+					Debug.Log("<color=green>_terrain.UpdateLayer</color>");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -521,6 +521,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
+					Debug.Log("_imagery.UpdateLayer");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{
@@ -537,6 +538,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if (layerUpdateArgs != null)
 				{
+					Debug.Log("_terrain.UpdateLayer");
 					_mapVisualizer.ReregisterTilesTo(layerUpdateArgs.factory);
 					if (layerUpdateArgs.effectsVectorLayer)
 					{
@@ -553,6 +555,7 @@ namespace Mapbox.Unity.Map
 				LayerUpdateArgs layerUpdateArgs = eventArgs as LayerUpdateArgs;
 				if(layerUpdateArgs != null)
 				{
+					Debug.Log("_vectorData.UpdateLayer");
 					_mapVisualizer.UnregisterTilesFrom(layerUpdateArgs.factory);
 					VectorData.UpdateFactorySettings();
 					_mapVisualizer.ReregisterTilesTo(VectorData.Factory);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -18,8 +18,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		protected ElevationLayerProperties _elevationOptions = new ElevationLayerProperties();
 		protected TerrainDataFetcher DataFetcher;
 
-		public event Action OnMapIdUpdated = delegate { };
-
 		public TerrainDataFetcher GetFetcher()
 		{
 			return DataFetcher;

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
@@ -50,7 +50,7 @@
 				if (value != _layerProperty.sourceOptions.Id)
 				{
 					_layerProperty.sourceOptions.Id = value;
-					_layerProperty.UpdateProperty();
+					_layerProperty.HasChanged = true;
 				}
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -123,16 +123,18 @@
 			SetStrategy();
 
 			_elevationFactory.SetOptions(_layerProperty);
-			_layerProperty.OnPropertyUpdated += () =>
-			{
-				//terrain factory uses strategy objects and they are controlled by layer
-				//so we have to refresh that first
-				SetStrategy();
-				//pushing new settings to factory directly
-				Factory.SetOptions(_layerProperty);
-				//notifying map to reload existing tiles
-				NotifyUpdateLayer(_elevationFactory, true);
-			};
+			_layerProperty.PropertyHasChanged += RedrawLayer;
+		}
+
+		public void RedrawLayer(object sender, System.EventArgs e)
+		{
+			//terrain factory uses strategy objects and they are controlled by layer
+			//so we have to refresh that first
+			SetStrategy();
+			//pushing new settings to factory directly
+			Factory.SetOptions(_layerProperty);
+			//notifying map to reload existing tiles
+			NotifyUpdateLayer(_elevationFactory, true);
 		}
 
 		public void SetStrategy()

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -125,21 +125,24 @@
 		public void Initialize()
 		{
 			_elevationFactory = ScriptableObject.CreateInstance<TerrainFactoryBase>();
-			SetStrategy();
-
-			_elevationFactory.SetOptions(_layerProperty);
+			SetFactoryOptions();
 			_layerProperty.PropertyHasChanged += RedrawLayer;
 		}
 
 		public void RedrawLayer(object sender, System.EventArgs e)
+		{
+			SetFactoryOptions();
+			//notifying map to reload existing tiles
+			NotifyUpdateLayer(_elevationFactory, true);
+		}
+
+		private void SetFactoryOptions()
 		{
 			//terrain factory uses strategy objects and they are controlled by layer
 			//so we have to refresh that first
 			SetStrategy();
 			//pushing new settings to factory directly
 			Factory.SetOptions(_layerProperty);
-			//notifying map to reload existing tiles
-			NotifyUpdateLayer(_elevationFactory, true);
 		}
 
 		private void SetStrategy()

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -60,7 +60,7 @@
 			{
 				_layerProperty.sourceType = terrainSource;
 				_layerProperty.sourceOptions.layerSource = MapboxDefaultElevation.GetParameters(terrainSource);
-				_layerProperty.UpdateProperty();
+				_layerProperty.HasChanged = true;
 			}
 			else
 			{
@@ -81,7 +81,7 @@
 				_layerProperty.elevationLayerType = ElevationLayerType.FlatTerrain;
 				Debug.LogWarning("Empty source - turning off terrain. ");
 			}
-			_layerProperty.UpdateProperty();
+			_layerProperty.HasChanged = true;
 		}
 
 		public void SetTerrainOptions(ElevationLayerType type, ElevationRequiredOptions requiredOptions = null, ElevationModificationOptions modificationOptions = null)
@@ -97,7 +97,7 @@
 			{
 				_layerProperty.modificationOptions = modificationOptions;
 			}
-			_layerProperty.UpdateProperty();
+			_layerProperty.HasChanged = true;
 		}
 
 		public void ShowSideWalls(float wallHeight, Material wallMaterial)
@@ -105,14 +105,14 @@
 			_layerProperty.sideWallOptions.isActive = true;
 			_layerProperty.sideWallOptions.wallHeight = wallHeight;
 			_layerProperty.sideWallOptions.wallMaterial = wallMaterial;
-			_layerProperty.UpdateProperty();
+			_layerProperty.HasChanged = true;
 		}
 
 		public void AddToUnityLayer(int layerId)
 		{
 			_layerProperty.unityLayerOptions.addToLayer = true;
 			_layerProperty.unityLayerOptions.layerId = layerId;
-			_layerProperty.UpdateProperty();
+			_layerProperty.HasChanged = true;
 		}
 
 		public void Initialize(LayerProperties properties)


### PR DESCRIPTION
**Related issue**

Map updates.

**Description of changes**

Image and terrain drawers now use a single, dependable method to detect changes; one             EditorHelper.CheckForModifiedProperty call at the end of OnGUI.

Add colored debug.log messages in Abstract Map to help debug section changes.

Known runtime update issues:

- Changing Data Source in Terrain section throws errors in console.
- If ElevationLayeType is changed to Globe, changing back to other option does not redraw the map to the correct size
- enabling ShowSidewalls in terrain section immediately throws an argument out of range error.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
