### PR TITLE
Fix ui errors vector section

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
@@ -24,7 +24,6 @@
 
 		public void DrawUI(SerializedProperty layerProperty, VectorPrimitiveType primitiveTypeProp, VectorSourceType sourceType)
 		{
-			//layerProperty.serializedObject.Update();
 
 			showGameplay = EditorGUILayout.Foldout(showGameplay, "Behavior Modifiers");
 			if (showGameplay)
@@ -78,7 +77,6 @@
 
 		private void DrawMeshModifiers(SerializedProperty property)
 		{
-			//property.serializedObject.Update();
 
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.LabelField(new GUIContent
@@ -144,7 +142,6 @@
 
 		private void DrawGoModifiers(SerializedProperty property)
 		{
-			//property.serializedObject.Update();
 
 			EditorGUILayout.BeginVertical();
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/BehaviorModifiersSectionDrawer.cs
@@ -24,7 +24,7 @@
 
 		public void DrawUI(SerializedProperty layerProperty, VectorPrimitiveType primitiveTypeProp, VectorSourceType sourceType)
 		{
-			layerProperty.serializedObject.Update();
+			//layerProperty.serializedObject.Update();
 
 			showGameplay = EditorGUILayout.Foldout(showGameplay, "Behavior Modifiers");
 			if (showGameplay)
@@ -78,7 +78,7 @@
 
 		private void DrawMeshModifiers(SerializedProperty property)
 		{
-			property.serializedObject.Update();
+			//property.serializedObject.Update();
 
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.LabelField(new GUIContent
@@ -144,7 +144,7 @@
 
 		private void DrawGoModifiers(SerializedProperty property)
 		{
-			property.serializedObject.Update();
+			//property.serializedObject.Update();
 
 			EditorGUILayout.BeginVertical();
 
@@ -178,7 +178,7 @@
 					{
 						gofac.DeleteArrayElementAtIndex(ind);
 					}
-					if(elementWasDeleted)
+					if (elementWasDeleted)
 					{
 						EditorHelper.CheckForModifiedProperty(property);
 					}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CoreVectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CoreVectorLayerPropertiesDrawer.cs
@@ -17,7 +17,7 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			property.serializedObject.Update();
+			//property.serializedObject.Update();
 
 			EditorGUI.BeginProperty(position, null, property);
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CoreVectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CoreVectorLayerPropertiesDrawer.cs
@@ -17,7 +17,6 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			//property.serializedObject.Update();
 
 			EditorGUI.BeginProperty(position, null, property);
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
@@ -83,7 +83,7 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			property.serializedObject.Update();
+			//property.serializedObject.Update();
 
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
 
@@ -192,7 +192,7 @@
 
 					EditorGUI.BeginChangeCheck();
 					EditorGUILayout.PropertyField(matList.GetArrayElementAtIndex(0), new GUIContent { text = "Top Material", tooltip = "Unity material to use for extruded top/roof mesh. " });
-					if(EditorGUI.EndChangeCheck())
+					if (EditorGUI.EndChangeCheck())
 					{
 						EditorHelper.CheckForModifiedProperty(property);
 					}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
@@ -83,7 +83,6 @@
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			//property.serializedObject.Update();
 
 			objectId = property.serializedObject.targetObject.GetInstanceID().ToString();
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ModelingSectionDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ModelingSectionDrawer.cs
@@ -26,7 +26,7 @@
 
 		public void DrawUI(SerializedProperty subLayerCoreOptions, SerializedProperty layerProperty, VectorPrimitiveType primitiveTypeProp)
 		{
-			subLayerCoreOptions.serializedObject.Update();
+			//subLayerCoreOptions.serializedObject.Update();
 
 			objectId = layerProperty.serializedObject.targetObject.GetInstanceID().ToString();
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ModelingSectionDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ModelingSectionDrawer.cs
@@ -26,7 +26,6 @@
 
 		public void DrawUI(SerializedProperty subLayerCoreOptions, SerializedProperty layerProperty, VectorPrimitiveType primitiveTypeProp)
 		{
-			//subLayerCoreOptions.serializedObject.Update();
 
 			objectId = layerProperty.serializedObject.targetObject.GetInstanceID().ToString();
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
@@ -56,11 +56,15 @@
 				EditorGUI.indentLevel++;
 				EditorGUILayout.BeginHorizontal();
 				GUILayout.Space(EditorGUI.indentLevel * 12);
+
+				EditorGUI.BeginChangeCheck();
 				if (GUILayout.Button(new GUIContent("Add New Empty"), (GUIStyle)"minibutton"))
 				{
 					propertyFilters.arraySize++;
+				}
+				if (EditorGUI.EndChangeCheck())
+				{
 					EditorHelper.CheckForModifiedProperty(property);
-					property.serializedObject.Update();
 				}
 				EditorGUILayout.EndHorizontal();
 				EditorGUI.indentLevel--;
@@ -119,7 +123,6 @@
 				EditorHelper.CheckForModifiedProperty(originalProperty);
 			}
 
-			//EditorGUI.BeginChangeCheck();
 			switch ((LayerFilterOperationType)filterOperatorProp.enumValueIndex)
 			{
 				case LayerFilterOperationType.IsEqual:
@@ -137,16 +140,16 @@
 				default:
 					break;
 			}
-			if (EditorGUI.EndChangeCheck())
-			{
-				EditorHelper.CheckForModifiedProperty(originalProperty);
-			}
 
+			EditorGUI.BeginChangeCheck();
 			if (GUILayout.Button(new GUIContent(" X "), (GUIStyle)"minibuttonright", GUILayout.Width(30)))
 			{
 				propertyFilters.DeleteArrayElementAtIndex(index);
+			}
+
+			if (EditorGUI.EndChangeCheck())
+			{
 				EditorHelper.CheckForModifiedProperty(originalProperty);
-				originalProperty.serializedObject.Update();
 			}
 			EditorGUILayout.EndHorizontal();
 
@@ -156,7 +159,7 @@
 
 		private void DrawPropertyDropDown(SerializedProperty originalProperty, SerializedProperty filterProperty)
 		{
-			originalProperty.serializedObject.Update();
+			//originalProperty.serializedObject.Update();
 			var selectedLayerName = originalProperty.FindPropertyRelative("_selectedLayerName").stringValue;
 			AbstractMap mapObject = (AbstractMap)originalProperty.serializedObject.targetObject;
 			TileJsonData tileJsonData = mapObject.VectorData.LayerProperty.tileJsonData;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
@@ -159,7 +159,6 @@
 
 		private void DrawPropertyDropDown(SerializedProperty originalProperty, SerializedProperty filterProperty)
 		{
-			//originalProperty.serializedObject.Update();
 			var selectedLayerName = originalProperty.FindPropertyRelative("_selectedLayerName").stringValue;
 			AbstractMap mapObject = (AbstractMap)originalProperty.serializedObject.targetObject;
 			TileJsonData tileJsonData = mapObject.VectorData.LayerProperty.tileJsonData;


### PR DESCRIPTION
Fixes ui errors when adding new layers + filters. 
serializedObject.Update() cannot be used in the middle of changes, it should only be used once a frame in the topmost property drawer. Calling update mid frame may lose changes and leave serialized object in a bad state. 