### PR TITLE
Removing feature layers now triggers VectorLayer.RemoveVectorLayer

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
@@ -276,25 +276,25 @@
 
 				if (GUILayout.Button(new GUIContent("Remove Selected"), (GUIStyle)"minibuttonright"))
 				{
-					bool layerWasRemoved = false;
 					foreach (var index in selectedLayers.OrderByDescending(i => i))
 					{
 						if (layerTreeView != null)
 						{
+							var subLayer = subLayerArray.GetArrayElementAtIndex(index - FeatureSubLayerTreeView.uniqueId);
+
+							VectorLayerProperties vectorLayerProperties = (VectorLayerProperties)EditorHelper.GetTargetObjectOfProperty(property);
+							VectorSubLayerProperties vectorSubLayerProperties = (VectorSubLayerProperties)EditorHelper.GetTargetObjectOfProperty(subLayer);
+
+							vectorLayerProperties.OnSubLayerPropertyRemoved(new VectorLayerUpdateArgs { property = vectorSubLayerProperties });
+
 							layerTreeView.RemoveItemFromTree(index);
 							subLayerArray.DeleteArrayElementAtIndex(index - FeatureSubLayerTreeView.uniqueId);
 							layerTreeView.treeModel.SetData(GetData(subLayerArray));
-							layerWasRemoved = true;
 						}
 					}
 
 					selectedLayers = new int[0];
 					layerTreeView.SetSelection(selectedLayers);
-
-					if (layerWasRemoved)
-					{
-						EditorHelper.CheckForModifiedProperty(property);
-					}
 				}
 
 				EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
**Description of changes**

Removing feature layers through UI calls vectorLayerProperties.OnSubLayerPropertyRemoved to trigger VectorLayer.RemoveVectorLayer

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
