### PR TITLE
Zombie object fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
@@ -276,25 +276,25 @@
 
 				if (GUILayout.Button(new GUIContent("Remove Selected"), (GUIStyle)"minibuttonright"))
 				{
-					bool layerWasRemoved = false;
 					foreach (var index in selectedLayers.OrderByDescending(i => i))
 					{
 						if (layerTreeView != null)
 						{
+							var subLayer = subLayerArray.GetArrayElementAtIndex(index - FeatureSubLayerTreeView.uniqueId);
+
+							VectorLayerProperties vectorLayerProperties = (VectorLayerProperties)EditorHelper.GetTargetObjectOfProperty(property);
+							VectorSubLayerProperties vectorSubLayerProperties = (VectorSubLayerProperties)EditorHelper.GetTargetObjectOfProperty(subLayer);
+
+							vectorLayerProperties.OnSubLayerPropertyRemoved(new VectorLayerUpdateArgs { property = vectorSubLayerProperties });
+
 							layerTreeView.RemoveItemFromTree(index);
 							subLayerArray.DeleteArrayElementAtIndex(index - FeatureSubLayerTreeView.uniqueId);
 							layerTreeView.treeModel.SetData(GetData(subLayerArray));
-							layerWasRemoved = true;
 						}
 					}
 
 					selectedLayers = new int[0];
 					layerTreeView.SetSelection(selectedLayers);
-
-					if (layerWasRemoved)
-					{
-						EditorHelper.CheckForModifiedProperty(property);
-					}
 				}
 
 				EditorGUILayout.EndHorizontal();

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -163,6 +163,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 		public virtual void RemoveVectorLayerVisualizer(LayerVisualizerBase subLayer)
 		{
+			subLayer.ClearCaches();
 			if (_layerBuilder.ContainsKey(subLayer.Key))
 			{
 				if (Properties.vectorSubLayers.Contains(subLayer.SubLayerProperties))
@@ -183,22 +184,26 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			_properties = (VectorLayerProperties)options;
 			if (_layerBuilder != null)
 			{
-				_layerBuilder.Clear();
-				// TODO : IS THIS CODE REALLY REQUIRED?
-				//CreateLayerVisualizers();
-				//foreach (var layer in _layerBuilder)
-				//{
-				//	foreach (var item in layer.Value)
-				//	{
-				//		(item as VectorLayerVisualizer).SetProperties(null);
-				//		item.Initialize();
-				//	}
-				//}
+				RemoveAllLayerVisualiers();
 
 				CreatePOILayerVisualizers();
 
 				CreateLayerVisualizers();
 			}
+		}
+
+		private void RemoveAllLayerVisualiers()
+		{
+			//Clearing gameobjects pooled and managed by modifiers to prevent zombie gameobjects.
+			foreach (var pairs in _layerBuilder)
+			{
+				foreach (var layerVisualizerBase in pairs.Value)
+				{
+					layerVisualizerBase.ClearCaches();
+				}
+			}
+
+			_layerBuilder.Clear();
 		}
 
 		protected override void OnRegistered(UnityTile tile)

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Interfaces/LayerVisualizerBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Interfaces/LayerVisualizerBase.cs
@@ -32,6 +32,11 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 		{
 
 		}
+
+		public virtual void ClearCaches()
+		{
+			
+		}
 		public void UnregisterTile(UnityTile tile)
 		{
 			OnUnregisterTile(tile);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -746,5 +746,11 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 			}
 			UnbindSubLayerEvents();
 		}
+
+		public override void ClearCaches()
+		{
+			_idPool.Clear();
+			_defaultStack.ClearCaches();
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifier.cs
@@ -28,5 +28,10 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		{
 			
 		}
+
+		public virtual void ClearCaches()
+		{
+
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
@@ -110,6 +110,23 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			}
 		}
 
+		public override void ClearCaches()
+		{
+			foreach (var go in _pool)
+			{
+				Destroy(go);
+			}
+			_pool.Clear();
+			foreach (var tileObject in _objects)
+			{
+				foreach (var go in tileObject.Value)
+				{
+					Destroy(go);
+				}
+			}
+			_objects.Clear();
+		}
+
 		private GameObject GetObject(int index, GameObject go)
 		{
 			GameObject ob;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/ReplaceFeatureCollectionModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/ReplaceFeatureCollectionModifier.cs
@@ -11,19 +11,16 @@
 	public class FeatureBundle
 	{
 		//public name param will be displayed in inspector list ui instead of element x...
-		[HideInInspector]
-		public string Name;
+		[HideInInspector] public string Name;
 
 		public bool active;
 
 		public GameObject prefab;
 		public bool scaleDownWithWorld = true;
 
-		[Geocode]
-		public List<string> _prefabLocations = new List<string>();
+		[Geocode] public List<string> _prefabLocations = new List<string>();
 
 		public List<string> _explicitlyBlockedFeatureIds = new List<string>();
-
 	}
 
 	/// <summary>
@@ -32,7 +29,6 @@
 	[CreateAssetMenu(menuName = "Mapbox/Modifiers/Replace Feature Collection Modifier")]
 	public class ReplaceFeatureCollectionModifier : GameObjectModifier, IReplacementCriteria
 	{
-
 		public List<FeatureBundle> features = new List<FeatureBundle>();
 
 		private List<ReplaceFeatureModifier> _replaceFeatureModifiers;
@@ -49,6 +45,19 @@
 		public override void Initialize()
 		{
 			base.Initialize();
+
+			if (_replaceFeatureModifiers != null && _replaceFeatureModifiers.Count > 0)
+			{
+				foreach (var replaceFeatureModifier in _replaceFeatureModifiers)
+				{
+					if (replaceFeatureModifier != null)
+					{
+						replaceFeatureModifier.ClearCaches();
+					}
+				}
+			}
+
+
 			_replaceFeatureModifiers = new List<ReplaceFeatureModifier>();
 			foreach (FeatureBundle feature in features)
 			{
@@ -76,6 +85,7 @@
 				{
 					continue;
 				}
+
 				modifier.FeaturePreProcess(feature);
 			}
 		}
@@ -88,6 +98,7 @@
 				{
 					continue;
 				}
+
 				modifier.SetProperties(properties);
 			}
 		}
@@ -100,11 +111,13 @@
 				{
 					continue;
 				}
-				if(modifier.ShouldReplaceFeature(feature))
+
+				if (modifier.ShouldReplaceFeature(feature))
 				{
 					return true;
 				}
 			}
+
 			return false;
 		}
 
@@ -121,6 +134,14 @@
 			foreach (ReplaceFeatureModifier modifier in _replaceFeatureModifiers)
 			{
 				modifier.OnPoolItem(vectorEntity);
+			}
+		}
+
+		public override void ClearCaches()
+		{
+			foreach (var subModules in _replaceFeatureModifiers)
+			{
+				subModules.ClearCaches();
 			}
 		}
 	}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/ReplaceFeatureModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/ReplaceFeatureModifier.cs
@@ -304,5 +304,14 @@
 			go.SetActive(false);
 			go.transform.SetParent(_poolGameObject.transform, false);
 		}
+
+		public override void ClearCaches()
+		{
+			foreach (var gameObject in _objects.Values)
+			{
+				Destroy(gameObject);
+			}
+			Destroy(_poolGameObject);
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStack.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStack.cs
@@ -230,5 +230,28 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 
 			return _tempVectorEntity.GameObject;
 		}
+
+		public override void ClearCaches()
+		{
+			foreach (var modifier in GoModifiers)
+			{
+				modifier.ClearCaches();
+			}
+			foreach (var vectorEntity in _pool.GetQueue())
+			{
+				Destroy(vectorEntity.GameObject);
+			}
+
+			foreach (var tileTuple in _activeObjects)
+			{
+				foreach (var vectorEntity in tileTuple.Value)
+				{
+					Destroy(vectorEntity.GameObject);
+				}
+			}
+			_pool.Clear();
+			_activeObjects.Clear();
+			_pool.Clear();
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStackBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/ModifierStackBase.cs
@@ -32,5 +32,10 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		{
 
 		}
+
+		public virtual void ClearCaches()
+		{
+
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/ObjectPool.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/ObjectPool.cs
@@ -33,6 +33,11 @@
 		{
 			_objects.Clear();
 		}
+
+		public IEnumerable<T> GetQueue()
+		{
+			return _objects;
+		}
 	}
 }
 


### PR DESCRIPTION
fix layers leaving zombie objects when removed
fix replacefeaturemodifier and replacefeaturecollectionmodifier leaving zombie objects on layer toggle and remove

to test;
- open any scene, expand a tile in the hierarchy to see children easily
- toggle layers, children count shouldn't increase
- remove layers, children count should be zero when all layers are removed

- open replace feature scene
- toggle and remove building layer, see gameobjects destroyed

- open iconic buildings scene
- toggle  building layer, container object counts shouldn't increase
- remove building layer, all container object should dissappear

@atripathi-mb @greglemonmapbox 