### PR TITLE
remove custom setting from Terrain datasource options

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapboxEnums.cs
@@ -153,10 +153,10 @@
 		[Description("Mapbox Terrain provides digital elevation model with worldwide coverage. ")]
 #endif
 		MapboxTerrain,
-#if !ENABLE_WINMD_SUPPORT
-		[Description("Use custom digital elevation model tileset.")]
-#endif
-		Custom,
+//#if !ENABLE_WINMD_SUPPORT
+//		[Description("Use custom digital elevation model tileset.")]
+//#endif
+//		Custom,
 #if !ENABLE_WINMD_SUPPORT
 		[Description("Render flat terrain.")]
 #endif

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -90,11 +90,11 @@
 					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
 					GUI.enabled = true;
 					break;
-				case ElevationSourceType.Custom:
-					layerSourceId.stringValue = CustomSourceMapId;
-					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
-					CustomSourceMapId = layerSourceId.stringValue;
-					break;
+//				case ElevationSourceType.Custom:
+//					layerSourceId.stringValue = CustomSourceMapId;
+//					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
+//					CustomSourceMapId = layerSourceId.stringValue;
+//					break;
 				default:
 					break;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/MapboxDefaultElevation.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/MapboxDefaultElevation.cs
@@ -17,8 +17,8 @@
 					};
 
 					break;
-				case ElevationSourceType.Custom:
-					throw new Exception("Invalid type : Custom");
+//				case ElevationSourceType.Custom:
+//					throw new Exception("Invalid type : Custom");
 				default:
 					break;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -210,12 +210,12 @@
 		/// <summary>
 		/// Sets the data source for Terrain Layer.
 		/// Defaults to MapboxTerrain.
-		/// Use <paramref name="terrainSource"/> = None, to disable the Terrain Layer. 
+		/// Use <paramref name="terrainSource"/> = None, to disable the Terrain Layer.
 		/// </summary>
 		/// <param name="terrainSource">Terrain source.</param>
 		public virtual void SetLayerSource(ElevationSourceType terrainSource = ElevationSourceType.MapboxTerrain)
 		{
-			if (terrainSource != ElevationSourceType.Custom && terrainSource != ElevationSourceType.None)
+			if (terrainSource != ElevationSourceType.None)
 			{
 				_layerProperty.sourceType = terrainSource;
 				_layerProperty.sourceOptions.layerSource = MapboxDefaultElevation.GetParameters(terrainSource);
@@ -228,22 +228,15 @@
 		}
 
 		/// <summary>
-		/// Sets the data source to a custom source for Terrain Layer. 
-		/// </summary> 
+		/// Sets the data source to a custom source for Terrain Layer.
+		/// </summary>
 		/// <param name="terrainSource">Terrain source.</param>
 		public virtual void SetLayerSource(string terrainSource)
 		{
-			if (!string.IsNullOrEmpty(terrainSource))
-			{
-				_layerProperty.sourceType = ElevationSourceType.Custom;
-				_layerProperty.sourceOptions.Id = terrainSource;
-			}
-			else
-			{
-				_layerProperty.sourceType = ElevationSourceType.None;
-				_layerProperty.elevationLayerType = ElevationLayerType.FlatTerrain;
-				Debug.LogWarning("Empty source - turning off terrain. ");
-			}
+			_layerProperty.sourceType = ElevationSourceType.None;
+			_layerProperty.elevationLayerType = ElevationLayerType.FlatTerrain;
+			Debug.LogWarning("Empty source - turning off terrain. ");
+
 			_layerProperty.HasChanged = true;
 		}
 		/// <summary>


### PR DESCRIPTION
@atripathi-mb I pushed this PR for removing custom option from terrain source dropbox but I don't like it at all. I think proper way to do this would be leaving everything same but just removing it from the dropbox but I couldn't do it and removed the enum (and all references to it of course). I'm pushing just in case we don't want to spend time on doing a proper fix and merge this as it's not the worst thing eithr.