### PR TITLE
Fixed issue where custom material array size was not getting set.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
@@ -443,7 +443,7 @@
 
 			//set custom style options.
 			var customMats = customStyleOptions.FindPropertyRelative("materials");
-			mats.arraySize = 2;
+			customMats.arraySize = 2;
 
 			var customTopMatArray = customMats.GetArrayElementAtIndex(0).FindPropertyRelative("Materials");
 			var customSideMatArray = customMats.GetArrayElementAtIndex(1).FindPropertyRelative("Materials");


### PR DESCRIPTION
**Description of changes**

Fixed issue where custom mat array size was not being set, resulting in new layers not being added.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
