### PR TITLE
Light, Dark and Color styles now set material render mode based on op…

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
@@ -9,6 +9,7 @@
 	using Mapbox.VectorTile.ExtensionMethods;
 	using System.IO;
 	using System.Collections.Generic;
+	using Mapbox.Unity.MeshGeneration.Modifiers;
 
 	public class StyleIconBundle
 	{
@@ -78,6 +79,25 @@
 			foreach (var key in _paletteIconBundles.Keys)
 			{
 				_paletteIconBundles[key].Load();
+			}
+		}
+
+		private void SetMaterialOpacity(SerializedProperty property, bool opacity)
+		{
+			var matList = property.FindPropertyRelative("materials");
+			if (matList.arraySize == 0)
+			{
+				matList.arraySize = 2;
+			}
+			// 0 = Opaque, 3 = Transparent...
+			float renderMode = (opacity) ? 0f : 3f;
+			for (int i = 0; i < matList.arraySize; i++)
+			{
+				var material = matList.GetArrayElementAtIndex(i);
+				var mat = material.FindPropertyRelative("Materials");
+				var mmm = mat.GetArrayElementAtIndex(0);
+				Material matty = (Material)EditorHelper.GetTargetObjectOfProperty(mmm);
+				matty.SetFloat("_Mode", renderMode);
 			}
 		}
 
@@ -153,12 +173,15 @@
 							break;
 						case StyleTypes.Light:
 							property.FindPropertyRelative("lightStyleOpacity").floatValue = EditorGUILayout.Slider("Opacity", property.FindPropertyRelative("lightStyleOpacity").floatValue, 0.0f, 1.0f);
+							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("lightStyleOpacity").floatValue, 1.0f));
 							break;
 						case StyleTypes.Dark:
 							property.FindPropertyRelative("darkStyleOpacity").floatValue = EditorGUILayout.Slider("Opacity", property.FindPropertyRelative("darkStyleOpacity").floatValue, 0.0f, 1.0f);
+							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("darkStyleOpacity").floatValue, 1.0f));
 							break;
 						case StyleTypes.Color:
 							property.FindPropertyRelative("colorStyleColor").colorValue = EditorGUILayout.ColorField("Color", property.FindPropertyRelative("colorStyleColor").colorValue);
+							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("colorStyleColor").colorValue.a, 1.0f));
 							break;
 						default:
 							break;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
@@ -9,7 +9,6 @@
 	using Mapbox.VectorTile.ExtensionMethods;
 	using System.IO;
 	using System.Collections.Generic;
-	using Mapbox.Unity.MeshGeneration.Modifiers;
 
 	public class StyleIconBundle
 	{

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/GeometryMaterialOptionsDrawer.cs
@@ -82,25 +82,6 @@
 			}
 		}
 
-		private void SetMaterialOpacity(SerializedProperty property, bool opacity)
-		{
-			var matList = property.FindPropertyRelative("materials");
-			if (matList.arraySize == 0)
-			{
-				matList.arraySize = 2;
-			}
-			// 0 = Opaque, 3 = Transparent...
-			float renderMode = (opacity) ? 0f : 3f;
-			for (int i = 0; i < matList.arraySize; i++)
-			{
-				var material = matList.GetArrayElementAtIndex(i);
-				var mat = material.FindPropertyRelative("Materials");
-				var mmm = mat.GetArrayElementAtIndex(0);
-				Material matty = (Material)EditorHelper.GetTargetObjectOfProperty(mmm);
-				matty.SetFloat("_Mode", renderMode);
-			}
-		}
-
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 
@@ -173,15 +154,12 @@
 							break;
 						case StyleTypes.Light:
 							property.FindPropertyRelative("lightStyleOpacity").floatValue = EditorGUILayout.Slider("Opacity", property.FindPropertyRelative("lightStyleOpacity").floatValue, 0.0f, 1.0f);
-							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("lightStyleOpacity").floatValue, 1.0f));
 							break;
 						case StyleTypes.Dark:
 							property.FindPropertyRelative("darkStyleOpacity").floatValue = EditorGUILayout.Slider("Opacity", property.FindPropertyRelative("darkStyleOpacity").floatValue, 0.0f, 1.0f);
-							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("darkStyleOpacity").floatValue, 1.0f));
 							break;
 						case StyleTypes.Color:
 							property.FindPropertyRelative("colorStyleColor").colorValue = EditorGUILayout.ColorField("Color", property.FindPropertyRelative("colorStyleColor").colorValue);
-							SetMaterialOpacity(property, Mathf.Approximately(property.FindPropertyRelative("colorStyleColor").colorValue.a, 1.0f));
 							break;
 						default:
 							break;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/MaterialModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/MaterialModifier.cs
@@ -27,6 +27,11 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			_options.PropertyHasChanged -= UpdateModifier;
 		}
 
+		private float GetRenderMode(float val)
+		{
+			return Mathf.Approximately(val, 1.0f) ? 0f : 3f;
+		}
+
 		public override void Run(VectorEntity ve, UnityTile tile)
 		{
 			var min = Math.Min(_options.materials.Length, ve.MeshFilter.mesh.subMeshCount);
@@ -51,12 +56,27 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			}
 			else
 			{
+				float renderMode = 0.0f;
+				switch (_options.style)
+				{
+					case StyleTypes.Light:
+						renderMode = GetRenderMode(_options.lightStyleOpacity);
+						break;
+					case StyleTypes.Dark:
+						renderMode = GetRenderMode(_options.darkStyleOpacity);
+						break;
+					case StyleTypes.Color:
+						renderMode = GetRenderMode(_options.colorStyleColor.a);
+						break;
+					default:
+						break;
+				}
 				for (int i = 0; i < min; i++)
 				{
 					mats[i] = _options.materials[i].Materials[UnityEngine.Random.Range(0, _options.materials[i].Materials.Length)];
+					mats[i].SetFloat("_Mode", renderMode);
 				}
 			}
-
 			ve.MeshRenderer.materials = mats;
 		}
 	}


### PR DESCRIPTION
**Description of changes**

Light, Dark and Color styles now set material render mode based on opacity settings.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
