### PR TITLE
Editor preview shared material fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -290,12 +290,29 @@ namespace Mapbox.Unity.MeshGeneration.Data
 					_rasterData.Compress(false);
 				}
 
+				Material material;
 
-				Material material = new Material(MeshRenderer.sharedMaterial);
+				if(MeshRenderer.sharedMaterial != null)
+				{
+					material = new Material(MeshRenderer.sharedMaterial);
+
+					if (Application.isEditor && !Application.isPlaying)
+					{
+						DestroyImmediate(MeshRenderer.sharedMaterial, true);
+					}
+					else
+					{
+						Destroy(MeshRenderer.sharedMaterial);
+					}
+				}
+				else
+				{
+					material = new Material(Shader.Find("Standard"));
+				}
+
 				material.mainTexture = _rasterData;
 				MeshRenderer.sharedMaterial = material;
 
-				//MeshRenderer.material.mainTexture = _rasterData;
 				RasterDataState = TilePropertyState.Loaded;
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -184,7 +184,6 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			gameObject.SetActive(true);
 
 			IsRecycled = false;
-			//MeshRenderer.enabled = true;
 
 
 			// Setup Loading as initial state - Unregistered
@@ -196,8 +195,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 		{
 			if (_loadingTexture && MeshRenderer != null)
 			{
-				MeshRenderer.material.mainTexture = _loadingTexture;
-				//MeshRenderer.enabled = false;
+				MeshRenderer.sharedMaterial.mainTexture = _loadingTexture;
 			}
 
 			gameObject.SetActive(false);
@@ -292,7 +290,12 @@ namespace Mapbox.Unity.MeshGeneration.Data
 					_rasterData.Compress(false);
 				}
 
-				MeshRenderer.material.mainTexture = _rasterData;
+
+				Material material = new Material(MeshRenderer.sharedMaterial);
+				material.mainTexture = _rasterData;
+				MeshRenderer.sharedMaterial = material;
+
+				//MeshRenderer.material.mainTexture = _rasterData;
 				RasterDataState = TilePropertyState.Loaded;
 			}
 		}


### PR DESCRIPTION
**Related issue**

https://github.com/mapbox/unity/issues/735#issuecomment-440370518

From @brnkhy comment:

`if we set material using material field, editor spams Instantiating material due to calling renderer.material during edit mode. This will leak materials into the scene. You most likely want to use renderer.sharedMaterial instead. errors.` **`if we use sharedMaterial, it creates some problems with tiles for example. They all get the last downloaded texture as they're all written on top of same field.`**

**Description of changes**

UnityTile.Recycle:
- Changed texture assignment target from material to shared material

UnityTile.SetRasterData:
- Raster texture no longer assigned directly to material.texture
- Instead, we create a new material instance using MeshRenderer.sharedMaterial as an input-
- we then assign the raster texture to this new material's mainTexture
- then we assign this material back to MeshRenderer.sharedMaterial

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
