### PR TITLE
Fix for preventing map-related gameobjects from saving when scene is …

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -759,6 +759,11 @@ namespace Mapbox.Unity.Map
 			TriggerTileRedrawForExtent(currentExtent);
 		}
 
+		void OnEnable()
+		{
+			IsPreviewEnabled = false;
+		}
+
 		// TODO: implement IDisposable, instead?
 		protected virtual void OnDestroy()
 		{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -165,6 +165,8 @@ namespace Mapbox.Unity.MeshGeneration.Data
 
 		internal void Initialize(IMapReadable map, UnwrappedTileId tileId, float scale, int zoom, Texture2D loadingTexture = null)
 		{
+			gameObject.hideFlags = HideFlags.DontSave;
+
 			ElevationType = TileTerrainType.None;
 			TileScale = scale;
 			_relativeScale = 1 / Mathf.Cos(Mathf.Deg2Rad * (float)map.CenterLatitudeLongitude.x);


### PR DESCRIPTION
**Related issue**

Fix for preventing map-related gameobjects from saving when scene is saved w/ editor preview enabled.

**Description of changes**

- Added HideFlags.DontSave to UnityTile.Initialize
- Set IsPreviewEnabled = false in AbstractMap.OnEnable();

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
