### PR TITLE
Fix for bug where deleted filters were being re-added to map on play.,

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
@@ -156,6 +156,7 @@
 			if (GUILayout.Button(new GUIContent(" X "), (GUIStyle)"minibuttonright", GUILayout.Width(30)))
 			{
 				vectorFilterOptions.RemoveFilter(index);
+				EditorUtility.SetDirty(property.serializedObject.targetObject);
 			}
 
 			EditorGUILayout.EndHorizontal();

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorFilterOptionsDrawer.cs
@@ -156,7 +156,7 @@
 			if (GUILayout.Button(new GUIContent(" X "), (GUIStyle)"minibuttonright", GUILayout.Width(30)))
 			{
 				vectorFilterOptions.RemoveFilter(index);
-				EditorUtility.SetDirty(property.serializedObject.targetObject);
+				propertyFilters.DeleteArrayElementAtIndex(index);
 			}
 
 			EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
**Related issue**

Closes https://github.com/mapbox/mapbox-unity-sdk/issues/1132

**Description of changes**

Added EditorUtility.SetDirty(property.serializedObject.targetObject) in filer remove button conditional block.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
