### PR TITLE
Disable preview button visibility when in play mode.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -113,18 +113,20 @@
 			GUIStyle style = new GUIStyle("Button");
 			style.alignment = TextAnchor.MiddleCenter;
 
-			prevProp.boolValue = GUILayout.Toggle(prevProp.boolValue, "Enable Preview", style);
-			GUI.color = guiColor;
-			if (prevProp.boolValue && !prev)
+			if(!Application.isPlaying)
 			{
-				((AbstractMap)serializedObject.targetObject).EnableEditorPreview();
+				prevProp.boolValue = GUILayout.Toggle(prevProp.boolValue, "Enable Preview", style);
+				GUI.color = guiColor;
+				if (prevProp.boolValue && !prev)
+				{
+					((AbstractMap)serializedObject.targetObject).EnableEditorPreview();
+				}
+				else if (prev && !prevProp.boolValue)
+				{
+					((AbstractMap)serializedObject.targetObject).DisableEditorPreview();
+				}
+				EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 			}
-			else if(prev && !prevProp.boolValue)
-			{
-				((AbstractMap)serializedObject.targetObject).DisableEditorPreview();
-			}
-
-			EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
 			ShowGeneral = EditorGUILayout.Foldout(ShowGeneral, new GUIContent { text = "GENERAL", tooltip = "Options related to map data" });
 


### PR DESCRIPTION
**Related issue**

Closes https://github.com/mapbox/unity/issues/735#issuecomment-444985371

**Description of changes**

Disable visibility of editor preview button when in play mode.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
