### PR TITLE
disable coroutines for editor preview

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -565,7 +565,7 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 
 					ProcessFeature(i, tile, tempLayerProperties, layer.Extent);
 
-					if (IsCoroutineBucketFull)
+					if (IsCoroutineBucketFull && !(Application.isEditor && !Application.isPlaying))
 					{
 						//Reset bucket..
 						_entityInCurrentCoroutine = 0;
@@ -592,7 +592,7 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 				callback(tile, this);
 		}
 
-		private bool ProcessFeature(int index, UnityTile tile, VectorLayerVisualizerProperties layerProperties, float layerExtent)
+		private bool  ProcessFeature(int index, UnityTile tile, VectorLayerVisualizerProperties layerProperties, float layerExtent)
 		{
 			var fe = layerProperties.vectorTileLayer.GetFeature(index);
 			List<List<Point2d<float>>> geom;


### PR DESCRIPTION
disable coroutines for editor preview to prevent a bug where corouties halting in editor

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
