### PR TITLE
change tile providers to be monobehaviours again

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/2_AstronautGame/AstronautGame.unity
+++ b/sdkproject/Assets/Mapbox/Examples/2_AstronautGame/AstronautGame.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,7 +38,8 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.45006508, g: 0.5001157, b: 0.57548237, a: 1}
+  m_IndirectSpecularColor: {r: 0.4500653, g: 0.5001161, b: 0.57548296, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -54,11 +55,10 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 40
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -116,10 +116,10 @@ NavMeshSettings:
 --- !u!1 &37135191
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1635791393252332, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1635791393252332, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 37135192}
   - component: {fileID: 37135193}
@@ -133,7 +133,7 @@ GameObject:
 --- !u!4 &37135192
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4779604382777758, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4779604382777758, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 37135191}
@@ -147,7 +147,7 @@ Transform:
 --- !u!114 &37135193
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114363624137296630, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114363624137296630, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 37135191}
@@ -168,10 +168,10 @@ MonoBehaviour:
 --- !u!1 &159634024
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1094528686802348, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1094528686802348, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 159634027}
   - component: {fileID: 159634025}
@@ -186,7 +186,7 @@ GameObject:
 --- !u!114 &159634025
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114105500206378512, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114105500206378512, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 159634024}
@@ -195,7 +195,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _initializeOnStart: 0
   _options:
     locationOptions:
       latitudeLongitude: 37.784179, -122.401583
@@ -224,6 +223,7 @@ MonoBehaviour:
       unityTileSize: 100
     loadingTexture: {fileID: 2800000, guid: e2896a92727704803a9c422b043eae89, type: 3}
     tileMaterial: {fileID: 2100000, guid: b9f23e9bce724fa4daac57ecded470b8, type: 2}
+  _initializeOnStart: 0
   _imagery:
     _layerProperty:
       sourceType: 2
@@ -323,6 +323,10 @@ MonoBehaviour:
           combineMeshes: 0
         lineGeometryOptions:
           Width: 1
+          MiterLimit: 0.2
+          RoundLimit: 1.05
+          JoinType: 1
+          CapType: 1
         filterOptions:
           _selectedLayerName: building
           filters: []
@@ -382,6 +386,10 @@ MonoBehaviour:
           combineMeshes: 0
         lineGeometryOptions:
           Width: 1
+          MiterLimit: 0.2
+          RoundLimit: 1.05
+          JoinType: 1
+          CapType: 1
         filterOptions:
           _selectedLayerName: landuse
           filters: []
@@ -443,6 +451,10 @@ MonoBehaviour:
           combineMeshes: 0
         lineGeometryOptions:
           Width: 1
+          MiterLimit: 0.2
+          RoundLimit: 1.05
+          JoinType: 1
+          CapType: 1
         filterOptions:
           _selectedLayerName: road
           filters:
@@ -539,75 +551,13 @@ MonoBehaviour:
         presetFeatureType: 1
         _maskValue: 0
         selectedTypes: 
-      - coreOptions:
-          sourceId: 
-          isActive: 0
-          sublayerName: b2
-          geometryType: 3
-          layerName: building
-          snapToTerrain: 1
-          combineMeshes: 0
-        lineGeometryOptions:
-          Width: 1
-        filterOptions:
-          _selectedLayerName: building
-          filters: []
-          combinerType: 0
-        extrusionOptions:
-          _selectedLayerName: building
-          extrusionType: 0
-          extrusionGeometryType: 0
-          propertyName: height
-          propertyDescription: Number. Height of building or part of building.
-          minimumHeight: 3
-          maximumHeight: 0.2
-          extrusionScaleFactor: 1
-        colliderOptions:
-          colliderType: 0
-        materialOptions:
-          style: 0
-          texturingType: 0
-          materials:
-          - Materials:
-            - {fileID: 0}
-          - Materials:
-            - {fileID: 0}
-          atlasInfo: {fileID: 0}
-          lightStyleOpacity: 1
-          darkStyleOpacity: 1
-          colorStyleColor: {r: 1, g: 1, b: 1, a: 1}
-          samplePalettes: 0
-          colorPalette: {fileID: 0}
-          customStyleOptions:
-            texturingType: 0
-            materials:
-            - Materials:
-              - {fileID: 0}
-            - Materials:
-              - {fileID: 0}
-            atlasInfo: {fileID: 0}
-            colorPalette: {fileID: 0}
-        performanceOptions:
-          isEnabled: 1
-          entityPerCoroutine: 20
-        honorBuildingIdSetting: 1
-        buildingsWithUniqueIds: 0
-        moveFeaturePositionTo: 0
-        MeshModifiers:
-        - {fileID: 11400000, guid: 4fe5c136889ae0347af431be7e59e489, type: 2}
-        - {fileID: 11400000, guid: b432bf85b0df280468dcfdaf5a9b90d0, type: 2}
-        - {fileID: 11400000, guid: 4dbdd9c4bb7ba4d41ac1b710cf40de49, type: 2}
-        GoModifiers:
-        - {fileID: 11400000, guid: cd82d41d9097fef4fb5dafaebde20bfa, type: 2}
-        presetFeatureType: 0
-        _maskValue: 0
-        selectedTypes: 
       locationPrefabList: []
   _tileProvider: {fileID: 0}
+  IsPreviewEnabled: 0
 --- !u!114 &159634026
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114086566548189782, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114086566548189782, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 159634024}
@@ -620,7 +570,7 @@ MonoBehaviour:
 --- !u!4 &159634027
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4310658642812482, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4310658642812482, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 159634024}
@@ -634,9 +584,9 @@ Transform:
 --- !u!1 &234181014
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 234181015}
   - component: {fileID: 234181019}
@@ -652,7 +602,7 @@ GameObject:
 --- !u!4 &234181015
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 234181014}
   m_LocalRotation: {x: 0.30470043, y: 0.10373317, z: -0.03340496, w: 0.94619304}
@@ -666,27 +616,31 @@ Transform:
 --- !u!81 &234181017
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 234181014}
   m_Enabled: 1
 --- !u!124 &234181018
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 234181014}
   m_Enabled: 1
 --- !u!20 &234181019
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 234181014}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -716,10 +670,10 @@ Camera:
 --- !u!1 &289230304
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1671354315346450, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1671354315346450, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 289230305}
   - component: {fileID: 289230306}
@@ -733,7 +687,7 @@ GameObject:
 --- !u!4 &289230305
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4508123490764572, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4508123490764572, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 289230304}
@@ -747,7 +701,7 @@ Transform:
 --- !u!114 &289230306
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114159034711449820, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114159034711449820, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 289230304}
@@ -964,15 +918,15 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &397025668
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1065618987163410, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1065618987163410, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1538829360}
   - component: {fileID: 397025670}
@@ -987,7 +941,7 @@ GameObject:
 --- !u!114 &397025669
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114668955501623132, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114668955501623132, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 397025668}
@@ -1005,7 +959,7 @@ MonoBehaviour:
 --- !u!114 &397025670
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114140835023345716, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114140835023345716, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 397025668}
@@ -1017,10 +971,10 @@ MonoBehaviour:
 --- !u!1 &444856203
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1844081552716966, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1844081552716966, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 444856204}
   - component: {fileID: 444856205}
@@ -1034,7 +988,7 @@ GameObject:
 --- !u!4 &444856204
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4385260180251512, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4385260180251512, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 444856203}
@@ -1048,7 +1002,7 @@ Transform:
 --- !u!114 &444856205
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114410157683913826, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114410157683913826, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 444856203}
@@ -1062,9 +1016,9 @@ MonoBehaviour:
 --- !u!1 &764432099
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 764432100}
   - component: {fileID: 764432101}
@@ -1078,7 +1032,7 @@ GameObject:
 --- !u!4 &764432100
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 764432099}
   m_LocalRotation: {x: -0.25388518, y: -0.07250805, z: 0.9643239, w: -0.019089768}
@@ -1091,7 +1045,7 @@ Transform:
 --- !u!108 &764432101
 Light:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 764432099}
   m_Enabled: 1
@@ -1118,6 +1072,7 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
@@ -1127,7 +1082,7 @@ Light:
 --- !u!4 &843921208
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4499799956889190, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4499799956889190, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1050211063}
@@ -1146,10 +1101,10 @@ Transform:
 --- !u!1 &1050211063
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1343136282922088, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1343136282922088, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 843921208}
   - component: {fileID: 1050211064}
@@ -1163,7 +1118,7 @@ GameObject:
 --- !u!114 &1050211064
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114785114324483884, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114785114324483884, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1050211063}
@@ -1181,10 +1136,10 @@ MonoBehaviour:
 --- !u!1 &1082879433
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1155921098649226, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1155921098649226, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1082879434}
   - component: {fileID: 1082879435}
@@ -1198,7 +1153,7 @@ GameObject:
 --- !u!4 &1082879434
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4249158653028356, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4249158653028356, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1082879433}
@@ -1212,7 +1167,7 @@ Transform:
 --- !u!114 &1082879435
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114357689223919402, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114357689223919402, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1082879433}
@@ -1230,9 +1185,9 @@ MonoBehaviour:
 --- !u!1 &1136482693
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1136482694}
   m_Layer: 0
@@ -1245,7 +1200,7 @@ GameObject:
 --- !u!4 &1136482694
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1136482693}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -1258,10 +1213,10 @@ Transform:
 --- !u!1 &1160898044
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1784694379802654, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 1784694379802654, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1160898045}
   - component: {fileID: 1160898046}
@@ -1275,7 +1230,7 @@ GameObject:
 --- !u!4 &1160898045
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4572037255418010, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4572037255418010, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1160898044}
@@ -1289,7 +1244,7 @@ Transform:
 --- !u!114 &1160898046
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114472907270853152, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 114472907270853152, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1160898044}
@@ -1308,13 +1263,13 @@ MonoBehaviour:
     _locationLogFile: {fileID: 0}
 --- !u!1 &1176362809 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1438539700862716, guid: b4281c0219e45624e855839527bdc6f1,
+  m_CorrespondingSourceObject: {fileID: 1438539700862716, guid: b4281c0219e45624e855839527bdc6f1,
     type: 2}
   m_PrefabInternal: {fileID: 1502952404}
 --- !u!114 &1176362810
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1176362809}
   m_Enabled: 1
@@ -1337,13 +1292,13 @@ MonoBehaviour:
   cam: {fileID: 234181019}
 --- !u!95 &1176362811 stripped
 Animator:
-  m_PrefabParentObject: {fileID: 95022966287224496, guid: b4281c0219e45624e855839527bdc6f1,
+  m_CorrespondingSourceObject: {fileID: 95022966287224496, guid: b4281c0219e45624e855839527bdc6f1,
     type: 2}
   m_PrefabInternal: {fileID: 1502952404}
 --- !u!114 &1176362812
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1176362809}
   m_Enabled: 1
@@ -1353,15 +1308,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!4 &1176362814 stripped
 Transform:
-  m_PrefabParentObject: {fileID: 4601729990306218, guid: b4281c0219e45624e855839527bdc6f1,
+  m_CorrespondingSourceObject: {fileID: 4601729990306218, guid: b4281c0219e45624e855839527bdc6f1,
     type: 2}
   m_PrefabInternal: {fileID: 1502952404}
 --- !u!1 &1188978833
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1188978836}
   - component: {fileID: 1188978835}
@@ -1376,7 +1331,7 @@ GameObject:
 --- !u!114 &1188978834
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1188978833}
   m_Enabled: 1
@@ -1394,7 +1349,7 @@ MonoBehaviour:
 --- !u!114 &1188978835
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1188978833}
   m_Enabled: 1
@@ -1408,7 +1363,7 @@ MonoBehaviour:
 --- !u!4 &1188978836
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1188978833}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -1421,9 +1376,9 @@ Transform:
 --- !u!1 &1220223447
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1220223451}
   - component: {fileID: 1220223450}
@@ -1440,7 +1395,7 @@ GameObject:
 --- !u!114 &1220223448
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1220223447}
   m_Enabled: 1
@@ -1456,7 +1411,7 @@ MonoBehaviour:
 --- !u!114 &1220223449
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1220223447}
   m_Enabled: 1
@@ -1477,7 +1432,7 @@ MonoBehaviour:
 --- !u!223 &1220223450
 Canvas:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1220223447}
   m_Enabled: 1
@@ -1497,7 +1452,7 @@ Canvas:
 --- !u!224 &1220223451
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1220223447}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -1516,7 +1471,7 @@ RectTransform:
 --- !u!114 &1220223452
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1220223447}
   m_Enabled: 1
@@ -1528,9 +1483,9 @@ MonoBehaviour:
 --- !u!1 &1426712541
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1426712542}
   m_Layer: 0
@@ -1543,7 +1498,7 @@ GameObject:
 --- !u!4 &1426712542
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1426712541}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -1556,9 +1511,9 @@ Transform:
 --- !u!1 &1466573009
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1466573011}
   - component: {fileID: 1466573010}
@@ -1572,7 +1527,7 @@ GameObject:
 --- !u!114 &1466573010
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1466573009}
   m_Enabled: 1
@@ -1586,7 +1541,7 @@ MonoBehaviour:
 --- !u!4 &1466573011
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1466573009}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -1651,12 +1606,12 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: b4281c0219e45624e855839527bdc6f1, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: b4281c0219e45624e855839527bdc6f1, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!4 &1538829360
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4961856903295740, guid: 35ce2bb4caba9434db5e656796b632b1,
+  m_CorrespondingSourceObject: {fileID: 4961856903295740, guid: 35ce2bb4caba9434db5e656796b632b1,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 397025668}
@@ -1670,9 +1625,9 @@ Transform:
 --- !u!1 &1746432969
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1746432973}
   - component: {fileID: 1746432972}
@@ -1688,7 +1643,7 @@ GameObject:
 --- !u!23 &1746432970
 MeshRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1746432969}
   m_Enabled: 0
@@ -1698,6 +1653,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1722,7 +1678,7 @@ MeshRenderer:
 --- !u!64 &1746432971
 MeshCollider:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1746432969}
   m_Material: {fileID: 0}
@@ -1736,14 +1692,14 @@ MeshCollider:
 --- !u!33 &1746432972
 MeshFilter:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1746432969}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!4 &1746432973
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1746432969}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -1756,9 +1712,9 @@ Transform:
 --- !u!1 &1962332871
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1962332872}
   - component: {fileID: 1962332874}
@@ -1773,7 +1729,7 @@ GameObject:
 --- !u!224 &1962332872
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1962332871}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -1791,7 +1747,7 @@ RectTransform:
 --- !u!114 &1962332873
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1962332871}
   m_Enabled: 0
@@ -1824,6 +1780,7 @@ MonoBehaviour:
 --- !u!222 &1962332874
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1962332871}
+  m_CullTransparentMesh: 0

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -690,12 +690,14 @@ namespace Mapbox.Unity.Map
 						{
 							if (!(TileProvider is QuadTreeTileProvider))
 							{
-								TileProvider = new QuadTreeTileProvider();
+								Destroy(TileProvider);
+								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 							}
 						}
 						else
 						{
-							TileProvider = new QuadTreeTileProvider();
+							Destroy(TileProvider);
+							TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 						}
 						break;
 					}
@@ -705,12 +707,14 @@ namespace Mapbox.Unity.Map
 						{
 							if (!(TileProvider is RangeTileProvider))
 							{
-								TileProvider = new RangeTileProvider();
+								Destroy(TileProvider);
+								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 						}
 						else
 						{
-							TileProvider = new RangeTileProvider();
+							Destroy(TileProvider);
+							TileProvider = gameObject.AddComponent<RangeTileProvider>();
 						}
 						break;
 					}
@@ -720,12 +724,14 @@ namespace Mapbox.Unity.Map
 						{
 							if (!(TileProvider is RangeAroundTransformTileProvider))
 							{
-								TileProvider = new RangeAroundTransformTileProvider();
+								Destroy(TileProvider);
+								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 							}
 						}
 						else
 						{
-							TileProvider = new RangeAroundTransformTileProvider();
+							Destroy(TileProvider);
+							TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 						}
 						break;
 					}

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
@@ -12,7 +12,7 @@ namespace Mapbox.Unity.Map.TileProviders
 		public HashSet<UnwrappedTileId> activeTiles;
 	}
 
-	public abstract class AbstractTileProvider : ITileProvider
+	public abstract class AbstractTileProvider : MonoBehaviour, ITileProvider
 	{
 		public event EventHandler<ExtentArgs> ExtentChanged;
 


### PR DESCRIPTION
remove unused vector layer in astronaut game demo scene
change tile providers to be monobehaviours again

globe demo scene should work with these changes now. would be good to test changing tile providers (runtime/editor) in any scene as well.

@jordy-isaac @atripathi-mb @greglemonmapbox 