### PR TITLE
Serialize tile dictionary

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
+++ b/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
@@ -287,7 +287,7 @@ Prefab:
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000015258789
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114731470950229392, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -587,26 +587,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _initializeOnStart: 1
   _options:
     locationOptions:
       latitudeLongitude: 0,0
       zoom: 3
     extentOptions:
       extentType: 3
-      cameraBoundsOptions:
-        camera: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
-      rangeAroundCenterOptions:
-        west: 1
-        north: 1
-        east: 1
-        south: 1
-      rangeAroundTransformOptions:
-        targetTransform: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
+      defaultExtents:
+        cameraBoundsOptions:
+          camera: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
+        rangeAroundCenterOptions:
+          west: 1
+          north: 1
+          east: 1
+          south: 1
+        rangeAroundTransformOptions:
+          targetTransform: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
     placementOptions:
       placementType: 1
       snapMapToZero: 0
@@ -615,13 +615,14 @@ MonoBehaviour:
       unityTileSize: 100
     loadingTexture: {fileID: 2800000, guid: e2896a92727704803a9c422b043eae89, type: 3}
     tileMaterial: {fileID: 2100000, guid: b9f23e9bce724fa4daac57ecded470b8, type: 2}
+  _initializeOnStart: 1
   _imagery:
     _layerProperty:
       sourceType: 4
       sourceOptions:
         isActive: 1
         layerSource:
-          Name: Streets
+          Name: Satellite
           Id: mapbox.satellite
           Modified: 
           UserName: 
@@ -641,8 +642,9 @@ MonoBehaviour:
           UserName: 
       elevationLayerType: 3
       requiredOptions:
-        addCollider: 0
         exaggerationFactor: 1
+      colliderOptions:
+        addCollider: 0
       modificationOptions:
         sampleCount: 10
         useRelativeHeight: 1
@@ -679,6 +681,7 @@ MonoBehaviour:
       vectorSubLayers: []
       locationPrefabList: []
   _tileProvider: {fileID: 1461465689}
+  IsPreviewEnabled: 0
 --- !u!4 &1461465688
 Transform:
   m_ObjectHideFlags: 0
@@ -750,7 +753,7 @@ MonoBehaviour:
   OnTileError:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mapbox.Unity.Map.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
+    m_TypeName: Mapbox.Unity.Map.TileProviders.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1951800002
 Prefab:

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/CameraMovement.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/CameraMovement.cs
@@ -99,7 +99,7 @@ namespace Mapbox.Examples
 				var x = Input.GetAxis("Horizontal");
 				var z = Input.GetAxis("Vertical");
 				var y = Input.GetAxis("Mouse ScrollWheel") * _zoomSpeed;
-				if (!(Mathf.Approximately(x, 0) || Mathf.Approximately(y, 0) || Mathf.Approximately(z, 0)))
+				if (!(Mathf.Approximately(x, 0) && Mathf.Approximately(y, 0) && Mathf.Approximately(z, 0)))
 				{
 					transform.localPosition += transform.forward * y + (_originalRotation * new Vector3(x * _panSpeed, 0, z * _panSpeed));
 					_map.UpdateMap();

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
@@ -5,6 +5,7 @@ namespace Mapbox.Examples
 	using Mapbox.Unity.Map;
 	using UnityEngine.UI;
 
+	[ExecuteInEditMode]
 	public class LoadingPanelController : MonoBehaviour
 	{
 		[SerializeField]
@@ -19,8 +20,12 @@ namespace Mapbox.Examples
 		AbstractMap _map;
 		void Awake()
 		{
+
 			_map = FindObjectOfType<AbstractMap>();
 			_map.OnInitialized += _map_OnInitialized;
+
+			_map.OnEditorPreviewEnabled += OnEditorPreviewEnabled;
+			_map.OnEditorPreviewDisabled += OnEditorPreviewDisabled;
 		}
 
 		void _map_OnInitialized()
@@ -44,8 +49,20 @@ namespace Mapbox.Examples
 					// when loading new tiles.
 					//_content.SetActive(true);
 				}
+
 			};
 		}
+
+		void OnEditorPreviewEnabled()
+		{
+			_content.SetActive(false);
+		}
+
+		void OnEditorPreviewDisabled()
+		{
+			_content.SetActive(true);
+		}
+
 
 		void Update()
 		{

--- a/sdkproject/Assets/Mapbox/README.txt
+++ b/sdkproject/Assets/Mapbox/README.txt
@@ -11,7 +11,7 @@ API: https://www.mapbox.com/mapbox-unity-sdk/api/
 
 
 
-Current version: 2.0.0, as of October 15th, 2018
+Current version: 2.0.1, as of December 21st, 2018
 
 Changelog: https://www.mapbox.com/mapbox-unity-sdk/docs/05-changelog.html
 

--- a/sdkproject/Assets/Mapbox/Unity/Constants.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Constants.cs
@@ -4,7 +4,7 @@ namespace Mapbox.Unity
 
 	public static class Constants
 	{
-		public const string SDK_VERSION = "2.0.0";
+		public const string SDK_VERSION = "2.0.1";
 
 		public static class Path
 		{

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -13,4 +13,10 @@
 		public Texture2D loadingTexture = null;
 		public Material tileMaterial = null;
 	}
+
+	[Serializable]
+	public class EditorPreviewOptions : MapboxDataProperty
+	{
+		public bool isPreviewEnabled = false;
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -18,6 +18,5 @@
 	public class EditorPreviewOptions : MapboxDataProperty
 	{
 		public bool isPreviewEnabled = false;
-		public bool wasPreviewDisabledFromOnEnable = false;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -18,5 +18,6 @@
 	public class EditorPreviewOptions : MapboxDataProperty
 	{
 		public bool isPreviewEnabled = false;
+		public bool wasPreviewDisabledFromOnEnable = false;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -20,22 +20,22 @@
 		[UnityEditor.Callbacks.DidReloadScripts]
 		private static void OnScriptsReloaded()
 		{
-			AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
-
-			if(abstractMap == null)
+			if (Application.isEditor)
 			{
-				return;
-			}
+				AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
 
-			UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
+				if(abstractMap == null)
+				{
+					return;
+				}
 
-			for (int i = 0; i < unityTiles.Length; i++)
-			{
-				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
-			}
+				UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
 
-			if(Application.isEditor)
-			{
+				for (int i = 0; i < unityTiles.Length; i++)
+				{
+					UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
+				}
+
 				if (EditorApplication.isPlaying)
 				{
 					abstractMap.DisableEditorPreview();

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -34,9 +34,18 @@
 				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
 			}
 
-			if(Application.isEditor && EditorApplication.isPlaying)
+			if(Application.isEditor)
 			{
-				EditorApplication.isPlaying = false;
+				if (EditorApplication.isPlaying)
+				{
+					EditorApplication.isPlaying = false;
+					return;
+				}
+				if (abstractMap.PreviewOptions.wasPreviewDisabledFromOnEnable)
+				{
+					abstractMap.EnableEditorPreview();
+					abstractMap.PreviewOptions.isPreviewEnabled = true;
+				}
 			}
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -38,13 +38,14 @@
 			{
 				if (EditorApplication.isPlaying)
 				{
-					EditorApplication.isPlaying = false;
+					abstractMap.DisableEditorPreview();
+					abstractMap.ForceRestartMap();
 					return;
 				}
-				if (abstractMap.PreviewOptions.wasPreviewDisabledFromOnEnable)
+				if (abstractMap.PreviewOptions.isPreviewEnabled == true)
 				{
+					abstractMap.DisableEditorPreview();
 					abstractMap.EnableEditorPreview();
-					abstractMap.PreviewOptions.isPreviewEnabled = true;
 				}
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -7,6 +7,8 @@
 	using System.Linq;
 	using System.Reflection;
 	using Mapbox.Unity.Map;
+	using Mapbox.Unity.MeshGeneration.Data;
+
 	/// <summary>
 	/// EditorHelper class provides methods for working with serialzed properties.
 	/// Methods in this class are based on the spacepuppy-unity-framework, available at the url below.
@@ -14,6 +16,30 @@
 	/// </summary>
 	public static class EditorHelper
 	{
+
+		[UnityEditor.Callbacks.DidReloadScripts]
+		private static void OnScriptsReloaded()
+		{
+			AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
+
+			if(abstractMap == null)
+			{
+				return;
+			}
+
+			UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
+
+			for (int i = 0; i < unityTiles.Length; i++)
+			{
+				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
+			}
+
+			if(Application.isEditor && EditorApplication.isPlaying)
+			{
+				EditorApplication.isPlaying = false;
+			}
+		}
+
 		public static void CheckForModifiedProperty<T>(SerializedProperty property, T targetObject, bool forceHasChanged = false)
 		{
 			MapboxDataProperty targetObjectAsDataProperty = GetMapboxDataPropertyObject(targetObject);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -104,7 +104,8 @@
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.Space();
 
-			var prevProp = serializedObject.FindProperty("IsPreviewEnabled");
+			var previewOptions = serializedObject.FindProperty("_previewOptions");
+			var prevProp = previewOptions.FindPropertyRelative("isPreviewEnabled");
 			var prev = prevProp.boolValue;
 
 			Color guiColor = GUI.color;

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -462,6 +462,10 @@ namespace Mapbox.Unity.Map
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
+			if (OnEditorPreviewEnabled != null)
+			{
+				OnEditorPreviewEnabled();
+			}
 		}
 
 		public void DisableEditorPreview()
@@ -474,6 +478,10 @@ namespace Mapbox.Unity.Map
 			_vectorData.UpdateLayer -= OnVectorDataUpdateLayer;
 			_vectorData.UnbindAllEvents();
 			_mapVisualizer.ClearMap();
+			if (OnEditorPreviewDisabled != null)
+			{
+				OnEditorPreviewDisabled();
+			}
 		}
 
 		protected IEnumerator SetupAccess()
@@ -685,50 +693,50 @@ namespace Mapbox.Unity.Map
 				switch (_options.extentOptions.extentType)
 				{
 					case MapExtentType.CameraBounds:
-					{
-						if (TileProvider != null)
 						{
-							if (!(TileProvider is QuadTreeTileProvider))
+							if (TileProvider != null)
+							{
+								if (!(TileProvider is QuadTreeTileProvider))
+								{
+									TileProvider = new QuadTreeTileProvider();
+								}
+							}
+							else
 							{
 								TileProvider = new QuadTreeTileProvider();
 							}
+							break;
 						}
-						else
-						{
-							TileProvider = new QuadTreeTileProvider();
-						}
-						break;
-					}
 					case MapExtentType.RangeAroundCenter:
-					{
-						if (TileProvider != null)
 						{
-							if (!(TileProvider is RangeTileProvider))
+							if (TileProvider != null)
+							{
+								if (!(TileProvider is RangeTileProvider))
+								{
+									TileProvider = new RangeTileProvider();
+								}
+							}
+							else
 							{
 								TileProvider = new RangeTileProvider();
 							}
+							break;
 						}
-						else
-						{
-							TileProvider = new RangeTileProvider();
-						}
-						break;
-					}
 					case MapExtentType.RangeAroundTransform:
-					{
-						if (TileProvider != null)
 						{
-							if (!(TileProvider is RangeAroundTransformTileProvider))
+							if (TileProvider != null)
+							{
+								if (!(TileProvider is RangeAroundTransformTileProvider))
+								{
+									TileProvider = new RangeAroundTransformTileProvider();
+								}
+							}
+							else
 							{
 								TileProvider = new RangeAroundTransformTileProvider();
 							}
+							break;
 						}
-						else
-						{
-							TileProvider = new RangeAroundTransformTileProvider();
-						}
-						break;
-					}
 					default:
 						break;
 				}
@@ -853,12 +861,12 @@ namespace Mapbox.Unity.Map
 
 		private void OnTileProviderChanged()
 		{
-//			var currentTileProvider = gameObject.GetComponent<AbstractTileProvider>();
-//
-//			if (currentTileProvider != null)
-//			{
-//				Destroy(currentTileProvider);
-//			}
+			//			var currentTileProvider = gameObject.GetComponent<AbstractTileProvider>();
+			//
+			//			if (currentTileProvider != null)
+			//			{
+			//				Destroy(currentTileProvider);
+			//			}
 			SetTileProvider();
 			_tileProvider.Initialize(this);
 			_tileProvider.UpdateTileExtent();
@@ -1081,6 +1089,9 @@ namespace Mapbox.Unity.Map
 		/// </summary>
 		public event Action OnUpdated = delegate { };
 		public event Action OnMapRedrawn = delegate { };
+
+		public event Action OnEditorPreviewEnabled = delegate { };
+		public event Action OnEditorPreviewDisabled = delegate { };
 		#endregion
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -430,13 +430,6 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			if (_previewOptions.isPreviewEnabled == true)
-			{
-				DisableEditorPreview();
-				_previewOptions.wasPreviewDisabledFromOnEnable = true;
-			}
-			_previewOptions.isPreviewEnabled = false;
-
 			if (_options.tileMaterial == null)
 			{
 				_options.tileMaterial = new Material(Shader.Find("Standard"));
@@ -450,14 +443,20 @@ namespace Mapbox.Unity.Map
 
 		protected virtual void Awake()
 		{
-			// Setup a visualizer to get a "Starter" map.
+			
 			foreach (Transform tr in transform)
 			{
 				Destroy(tr.gameObject);
 			}
 
+			// Setup a visualizer to get a "Starter" map.
 			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
-			_previewOptions.wasPreviewDisabledFromOnEnable = false;
+				
+			if (_previewOptions.isPreviewEnabled == true)
+			{
+				DisableEditorPreview();
+				_previewOptions.isPreviewEnabled = false;
+			}
 		}
 
 		// Use this for initialization
@@ -493,7 +492,6 @@ namespace Mapbox.Unity.Map
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
-			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 			if (OnEditorPreviewEnabled != null)
 			{
 				OnEditorPreviewEnabled();
@@ -502,7 +500,6 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			//_mapVisualizer.ClearActiveTileKeyValueLists();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				TileProvider.Destroy();
@@ -519,6 +516,12 @@ namespace Mapbox.Unity.Map
 			{
 				OnEditorPreviewDisabled();
 			}
+		}
+
+		public void ForceRestartMap()
+		{
+			Awake();
+			Start();
 		}
 
 		protected IEnumerator SetupAccess()

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap
+	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
 	{
 		#region Private Fields
 
@@ -33,6 +33,7 @@ namespace Mapbox.Unity.Map
 		[SerializeField] protected VectorLayer _vectorData = new VectorLayer();
 		[SerializeField] protected AbstractTileProvider _tileProvider;
 		[SerializeField] protected HashSet<UnwrappedTileId> _currentExtent;
+		[SerializeField] protected EditorPreviewOptions _previewOptions = new EditorPreviewOptions();
 
 		protected AbstractMapVisualizer _mapVisualizer;
 		protected float _unityTileSize = 1;
@@ -46,7 +47,7 @@ namespace Mapbox.Unity.Map
 		#endregion
 
 		#region Properties
-		public bool IsPreviewEnabled = false;
+		//public bool IsPreviewEnabled = false;
 
 		public AbstractMapVisualizer MapVisualizer
 		{
@@ -422,7 +423,11 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			IsPreviewEnabled = false;
+			if (_previewOptions.isPreviewEnabled == true)
+			{
+				DisableEditorPreview();
+			}
+			_previewOptions.isPreviewEnabled = false;
 
 			if (_options.tileMaterial == null)
 			{
@@ -459,6 +464,23 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		private void EnableDisablePreview(object sender, EventArgs e)
+		{
+			if (!Application.isPlaying)
+			{
+				if (_previewOptions.isPreviewEnabled)
+				{
+					Debug.Log("Preview Enabled");
+					EnableEditorPreview();
+				}
+				else
+				{
+					Debug.Log("Preview Disbaled");
+					DisableEditorPreview();
+				}
+			}
+		}
+
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
@@ -470,7 +492,11 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			TileProvider = null;
+			if (_options.extentOptions.extentType != MapExtentType.Custom)
+			{
+				TileProvider.Destroy();
+				TileProvider = null;
+			}
 			_imagery.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_terrain.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_vectorData.SubLayerRemoved -= OnVectorDataSubLayerRemoved;
@@ -698,12 +724,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
-									TileProvider = new QuadTreeTileProvider();
+									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new QuadTreeTileProvider();
+								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 							}
 							break;
 						}
@@ -713,12 +739,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
-									TileProvider = new RangeTileProvider();
+									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeTileProvider();
+								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 							break;
 						}
@@ -728,12 +754,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
-									TileProvider = new RangeAroundTransformTileProvider();
+									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeAroundTransformTileProvider();
+								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 							}
 							break;
 						}
@@ -1074,6 +1100,7 @@ namespace Mapbox.Unity.Map
 			_options.scalingOptions.unityTileSize = tileSizeInUnityUnits;
 			_options.scalingOptions.HasChanged = true;
 		}
+
 		#endregion
 
 		#region Events

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -796,7 +796,7 @@ namespace Mapbox.Unity.Map
 			{
 				_tileProvider.ExtentChanged -= OnMapExtentChanged;
 			}
-
+			_mapVisualizer.ClearMap();
 			_mapVisualizer.Destroy();
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
+	public class AbstractMap : MonoBehaviour, IMap
 	{
 		#region Private Fields
 
@@ -47,40 +47,6 @@ namespace Mapbox.Unity.Map
 		#endregion
 
 		#region Properties
-		//public bool IsPreviewEnabled = false;
-
-		public void OnBeforeSerialize()
-		{
-			if (_mapVisualizer == null)
-			{
-				return;
-			}
-			_mapVisualizer.SerializeActiveTileDictionary();
-			//Debug.Log("OnBeforeSerialize");
-			//_keys.Clear();
-			//_values.Clear();
-
-			//foreach (var kvp in _myDictionary)
-			//{
-			//	_keys.Add(kvp.Key);
-			//	_values.Add(kvp.Value);
-			//}
-		}
-
-		public void OnAfterDeserialize()
-		{
-			//Debug.Log("OnAfterDeserialize");
-
-			if(_mapVisualizer == null)
-			{
-				return;
-			}
-			_mapVisualizer.DeserializeActiveTileDictionary();
-			//_myDictionary = new Dictionary<int, string>();
-
-			//for (int i = 0; i != Math.Min(_keys.Count, _values.Count); i++)
-				//_myDictionary.Add(_keys[i], _values[i]);
-		}
 
 		public AbstractMapVisualizer MapVisualizer
 		{
@@ -497,6 +463,12 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		public void RestartMapFromScriptReload()
+		{
+			Awake();
+			Start();
+		}
+
 		private void EnableDisablePreview(object sender, EventArgs e)
 		{
 			if (!Application.isPlaying)
@@ -525,6 +497,7 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
+			//_mapVisualizer.ClearActiveTileKeyValueLists();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				TileProvider.Destroy();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -717,7 +717,6 @@ namespace Mapbox.Unity.Map
 
 		private void SetTileProvider()
 		{
-			//TileProvider = GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				ITileProviderOptions tileProviderOptions = _options.extentOptions.GetTileProviderOptions();
@@ -730,6 +729,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
@@ -745,6 +745,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
@@ -760,6 +761,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -49,6 +49,39 @@ namespace Mapbox.Unity.Map
 		#region Properties
 		//public bool IsPreviewEnabled = false;
 
+		public void OnBeforeSerialize()
+		{
+			if (_mapVisualizer == null)
+			{
+				return;
+			}
+			_mapVisualizer.SerializeActiveTileDictionary();
+			//Debug.Log("OnBeforeSerialize");
+			//_keys.Clear();
+			//_values.Clear();
+
+			//foreach (var kvp in _myDictionary)
+			//{
+			//	_keys.Add(kvp.Key);
+			//	_values.Add(kvp.Value);
+			//}
+		}
+
+		public void OnAfterDeserialize()
+		{
+			//Debug.Log("OnAfterDeserialize");
+
+			if(_mapVisualizer == null)
+			{
+				return;
+			}
+			_mapVisualizer.DeserializeActiveTileDictionary();
+			//_myDictionary = new Dictionary<int, string>();
+
+			//for (int i = 0; i != Math.Min(_keys.Count, _values.Count); i++)
+				//_myDictionary.Add(_keys[i], _values[i]);
+		}
+
 		public AbstractMapVisualizer MapVisualizer
 		{
 			get

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -80,6 +80,14 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		public EditorPreviewOptions PreviewOptions
+		{
+			get
+			{
+				return _previewOptions;
+			}
+		}
+
 		/// <summary>
 		/// The map options.
 		/// Options to control the behaviour of the map like location,extent, scale and placement.
@@ -425,6 +433,7 @@ namespace Mapbox.Unity.Map
 			if (_previewOptions.isPreviewEnabled == true)
 			{
 				DisableEditorPreview();
+				_previewOptions.wasPreviewDisabledFromOnEnable = true;
 			}
 			_previewOptions.isPreviewEnabled = false;
 
@@ -448,6 +457,7 @@ namespace Mapbox.Unity.Map
 			}
 
 			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 		}
 
 		// Use this for initialization
@@ -461,12 +471,6 @@ namespace Mapbox.Unity.Map
 					SetUpMap();
 				}
 			}
-		}
-
-		public void RestartMapFromScriptReload()
-		{
-			Awake();
-			Start();
 		}
 
 		private void EnableDisablePreview(object sender, EventArgs e)
@@ -489,6 +493,7 @@ namespace Mapbox.Unity.Map
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
+			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 			if (OnEditorPreviewEnabled != null)
 			{
 				OnEditorPreviewEnabled();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -34,6 +34,9 @@ namespace Mapbox.Unity.Map
 		protected Queue<UnityTile> _inactiveTiles = new Queue<UnityTile>();
 		private int _counter;
 
+		public List<UnwrappedTileId> _activeTilesKeys = new List<UnwrappedTileId>();
+		public List<UnityTile> _activeTilesValues = new List<UnityTile>();
+
 		private ModuleState _state;
 		public ModuleState State
 		{
@@ -65,6 +68,41 @@ namespace Mapbox.Unity.Map
 		public UnityTile GetUnityTileFromUnwrappedTileId(UnwrappedTileId tileId)
 		{
 			return _activeTiles[tileId];
+		}
+
+		public void SerializeActiveTileDictionary()
+		{
+			Debug.Log("..");
+			if(_activeTiles == null || _activeTiles.Count == 0)
+			{
+				return;
+			}
+
+			int count = Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count);
+
+			if(_activeTiles.Count == count)
+			{
+				return;
+			}
+
+			Debug.Log("SerializeActiveTileDictionary");
+			_activeTilesKeys.Clear();
+			_activeTilesValues.Clear();
+
+			foreach (var kvp in _activeTiles)
+			{
+				_activeTilesKeys.Add(kvp.Key);
+				_activeTilesValues.Add(kvp.Value);
+			}
+		}
+
+		public void DeserializeActiveTileDictionary()
+		{
+			Debug.Log("DeserializeActiveTileDictionary");
+			_activeTiles = new Dictionary<UnwrappedTileId, UnityTile>();
+
+			for (int i = 0; i != Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count); i++)
+				_activeTiles.Add(_activeTilesKeys[i], _activeTilesValues[i]);
 		}
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -262,16 +262,17 @@ namespace Mapbox.Unity.Map
 		public void ClearMap()
 		{
 			UnregisterAllTiles();
-
-			foreach (var tileFactory in Factories)
+			if (Factories != null)
 			{
-				if (tileFactory != null)
+				foreach (var tileFactory in Factories)
 				{
-					tileFactory.Clear();
-					DestroyImmediate(tileFactory);
+					if (tileFactory != null)
+					{
+						tileFactory.Clear();
+						DestroyImmediate(tileFactory);
+					}
 				}
 			}
-
 			foreach (var tileId in _activeTiles.Keys.ToList())
 			{
 				_activeTiles[tileId].ClearAssets();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -34,9 +34,6 @@ namespace Mapbox.Unity.Map
 		protected Queue<UnityTile> _inactiveTiles = new Queue<UnityTile>();
 		private int _counter;
 
-		public List<UnwrappedTileId> _activeTilesKeys = new List<UnwrappedTileId>();
-		public List<UnityTile> _activeTilesValues = new List<UnityTile>();
-
 		private ModuleState _state;
 		public ModuleState State
 		{
@@ -68,41 +65,6 @@ namespace Mapbox.Unity.Map
 		public UnityTile GetUnityTileFromUnwrappedTileId(UnwrappedTileId tileId)
 		{
 			return _activeTiles[tileId];
-		}
-
-		public void SerializeActiveTileDictionary()
-		{
-			Debug.Log("..");
-			if(_activeTiles == null || _activeTiles.Count == 0)
-			{
-				return;
-			}
-
-			int count = Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count);
-
-			if(_activeTiles.Count == count)
-			{
-				return;
-			}
-
-			Debug.Log("SerializeActiveTileDictionary");
-			_activeTilesKeys.Clear();
-			_activeTilesValues.Clear();
-
-			foreach (var kvp in _activeTiles)
-			{
-				_activeTilesKeys.Add(kvp.Key);
-				_activeTilesValues.Add(kvp.Value);
-			}
-		}
-
-		public void DeserializeActiveTileDictionary()
-		{
-			Debug.Log("DeserializeActiveTileDictionary");
-			_activeTiles = new Dictionary<UnwrappedTileId, UnityTile>();
-
-			for (int i = 0; i != Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count); i++)
-				_activeTiles.Add(_activeTilesKeys[i], _activeTilesValues[i]);
 		}
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -265,8 +265,11 @@ namespace Mapbox.Unity.Map
 
 			foreach (var tileFactory in Factories)
 			{
-				tileFactory.Clear();
-				DestroyImmediate(tileFactory);
+				if (tileFactory != null)
+				{
+					tileFactory.Clear();
+					DestroyImmediate(tileFactory);
+				}
 			}
 
 			foreach (var tileId in _activeTiles.Keys.ToList())
@@ -282,6 +285,7 @@ namespace Mapbox.Unity.Map
 			}
 
 			_inactiveTiles.Clear();
+			State = ModuleState.Initialized;
 		}
 
 		#region Events

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
@@ -12,7 +12,7 @@ namespace Mapbox.Unity.Map.TileProviders
 		public HashSet<UnwrappedTileId> activeTiles;
 	}
 
-	public abstract class AbstractTileProvider : ITileProvider
+	public abstract class AbstractTileProvider : MonoBehaviour, ITileProvider
 	{
 		public event EventHandler<ExtentArgs> ExtentChanged;
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -285,7 +285,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 				//reset image on null data
 				if (data == null)
 				{
-					MeshRenderer.material.mainTexture = null;
+					MeshRenderer.sharedMaterial.mainTexture = null;
 					return;
 				}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
@@ -29,12 +29,12 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 			}
 
 			if ((int)tile.ElevationType != (int)ElevationLayerType.GlobeTerrain ||
-			    tile.MeshFilter.mesh.vertexCount != RequiredVertexCount)
+				tile.MeshFilter.sharedMesh.vertexCount != RequiredVertexCount)
 			{
-				tile.MeshFilter.mesh.Clear();
+				tile.MeshFilter.sharedMesh.Clear();
 				tile.ElevationType = TileTerrainType.Globe;
 			}
-		
+
 			GenerateTerrainMesh(tile);
 		}
 
@@ -91,11 +91,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				}
 			}
 
-			tile.MeshFilter.mesh.SetVertices(verts);
-			tile.MeshFilter.mesh.SetTriangles(trilist, 0);
-			tile.MeshFilter.mesh.SetUVs(0, uvlist);
-			tile.MeshFilter.mesh.RecalculateBounds();
-			tile.MeshFilter.mesh.RecalculateNormals();
+			tile.MeshFilter.sharedMesh.SetVertices(verts);
+			tile.MeshFilter.sharedMesh.SetTriangles(trilist, 0);
+			tile.MeshFilter.sharedMesh.SetUVs(0, uvlist);
+			tile.MeshFilter.sharedMesh.RecalculateBounds();
+			tile.MeshFilter.sharedMesh.RecalculateNormals();
 
 			tile.transform.localPosition = Mapbox.Unity.Constants.Math.Vector3Zero;
 		}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/PrefabModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/PrefabModifier.cs
@@ -1,5 +1,3 @@
-using UnityEditor;
-
 namespace Mapbox.Unity.MeshGeneration.Modifiers
 {
 	using UnityEngine;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/UvModifier.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MeshModifiers/UvModifier.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 059a0278fa9c44be087aad07dbf4fdf9
+timeCreated: 1544732618
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -84,7 +84,10 @@ namespace Mapbox.Unity.Map
 
 		public void UnbindAllEvents()
 		{
-			_vectorTileFactory.UnbindEvents();
+			if (_vectorTileFactory != null)
+			{
+				_vectorTileFactory.UnbindEvents();
+			}
 		}
 
 		public void UpdateFactorySettings()

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs.meta
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a1a6d75cc30cc48ffb47fbd112800b60
+timeCreated: 1544732620
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdkproject/ProjectSettings/ProjectSettings.asset
+++ b/sdkproject/ProjectSettings/ProjectSettings.asset
@@ -3,11 +3,10 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 15
+  serializedVersion: 14
   productGUID: ca1e7757fee7043e7acc315135f2969e
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
-  AndroidEnableSustainedPerformanceMode: 0
   defaultScreenOrientation: 4
   targetDevice: 0
   useOnDemandResources: 0
@@ -17,7 +16,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -52,6 +51,7 @@ PlayerSettings:
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
+  tizenShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 1
   iosAllowHTTPDownload: 0
@@ -64,6 +64,7 @@ PlayerSettings:
   preserveFramebufferAlpha: 0
   disableDepthAndStencilBuffers: 0
   androidBlitType: 0
+  defaultIsFullScreen: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -90,7 +91,8 @@ PlayerSettings:
   visibleInBackground: 0
   allowFullscreenSwitch: 1
   graphicsJobMode: 0
-  fullscreenMode: 1
+  macFullscreenMode: 2
+  d3d11FullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -106,12 +108,18 @@ PlayerSettings:
   xboxOneLoggingLevel: 1
   xboxOneDisableEsram: 0
   xboxOnePresentImmediateThreshold: 0
-  switchQueueCommandMemory: 0
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
-  vulkanEnableSetSRGBWrite: 0
-  vulkanUseSWCommandBuffers: 0
+  wiiUTVResolution: 0
+  wiiUGamePadMSAA: 1
+  wiiUSupportsNunchuk: 0
+  wiiUSupportsClassicController: 0
+  wiiUSupportsBalanceBoard: 0
+  wiiUSupportsMotionPlus: 0
+  wiiUSupportsProController: 0
+  wiiUAllowScreenCapture: 1
+  wiiUControllerCount: 0
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -142,7 +150,6 @@ PlayerSettings:
     oculus:
       sharedDepthBuffer: 0
       dashSupport: 0
-    enable360StereoCapture: 0
   protectGraphicsMemory: 0
   useHDRDisplay: 0
   m_ColorGamuts: 00000000
@@ -172,7 +179,9 @@ PlayerSettings:
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
-  VertexChannelCompressionMask: 214
+  VertexChannelCompressionMask:
+    serializedVersion: 2
+    m_Bits: 4294901998
   iPhoneSdkVersion: 988
   iOSTargetOSVersionString: 11.2
   tvOSSdkVersion: 0
@@ -201,7 +210,6 @@ PlayerSettings:
   tvOSSmallIconLayers: []
   tvOSSmallIconLayers2x: []
   tvOSLargeIconLayers: []
-  tvOSLargeIconLayers2x: []
   tvOSTopShelfImageLayers: []
   tvOSTopShelfImageLayers2x: []
   tvOSTopShelfImageWideLayers: []
@@ -235,21 +243,13 @@ PlayerSettings:
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
-  iOSManualSigningProvisioningProfileType: 0
-  tvOSManualSigningProvisioningProfileType: 0
   appleEnableAutomaticSigning: 0
-  iOSRequireARKit: 0
-  appleEnableProMotion: 0
-  vulkanEditorSupport: 0
   clonedFromGUID: 00000000000000000000000000000000
-  templatePackageId: 
-  templateDefaultScene: 
-  AndroidTargetArchitectures: 5
+  AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
-  AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 1
   AndroidIsGame: 1
   AndroidEnableTango: 1
@@ -269,7 +269,6 @@ PlayerSettings:
       m_Width: 128
       m_Height: 128
       m_Kind: 45287
-  m_BuildTargetPlatformIcons: []
   m_BuildTargetBatching:
   - m_BuildTarget: iPhone
     m_StaticBatching: 0
@@ -348,9 +347,25 @@ PlayerSettings:
     m_EncodingQuality: 1
   - m_BuildTarget: PS4
     m_EncodingQuality: 1
-  m_BuildTargetGroupLightmapSettings: []
+  wiiUTitleID: 0005000011000000
+  wiiUGroupID: 00010000
+  wiiUCommonSaveSize: 4096
+  wiiUAccountSaveSize: 2048
+  wiiUOlvAccessKey: 0
+  wiiUTinCode: 0
+  wiiUJoinGameId: 0
+  wiiUJoinGameModeMask: 0000000000000000
+  wiiUCommonBossSize: 0
+  wiiUAccountBossSize: 0
+  wiiUAddOnUniqueIDs: []
+  wiiUMainThreadStackSize: 3072
+  wiiULoaderThreadStackSize: 1024
+  wiiUSystemHeapSize: 128
+  wiiUTVStartupScreen: {fileID: 0}
+  wiiUGamePadStartupScreen: {fileID: 0}
+  wiiUDrcBufferDisabled: 0
+  wiiUProfilerLibPath: 
   playModeTestRunnerEnabled: 1
-  runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
@@ -471,9 +486,6 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchSupportedNpadStyles: 3
-  switchNativeFsCacheSize: 32
-  switchIsHoldTypeHorizontal: 0
-  switchSupportedNpadCount: 8
   switchSocketConfigEnabled: 0
   switchTcpInitialSendBufferSize: 32
   switchTcpInitialReceiveBufferSize: 64
@@ -529,7 +541,6 @@ PlayerSettings:
   ps4pnFriends: 1
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
-  enableApplicationExit: 0
   restrictedAudioUsageRights: 0
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
@@ -600,6 +611,7 @@ PlayerSettings:
   psp2InfoBarOnStartup: 0
   psp2InfoBarColor: 0
   psp2ScriptOptimizationLevel: 0
+  psmSplashimage: {fileID: 0}
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: DefaultPackerPolicy
@@ -613,22 +625,14 @@ PlayerSettings:
   webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
+  webGLUseWasm: 0
   webGLCompressionFormat: 1
-  webGLLinkerTarget: 1
   scriptingDefineSymbols:
-    1: CROSS_PLATFORM_INPUT;UNITY_POST_PROCESSING_STACK_V2
-    4: CROSS_PLATFORM_INPUT;MOBILE_INPUT;UNITY_POST_PROCESSING_STACK_V2
-    7: CROSS_PLATFORM_INPUT;MOBILE_INPUT;UNITY_POST_PROCESSING_STACK_V2
-    13: UNITY_POST_PROCESSING_STACK_V2
+    1: CROSS_PLATFORM_INPUT
+    4: CROSS_PLATFORM_INPUT;MOBILE_INPUT
+    7: CROSS_PLATFORM_INPUT;MOBILE_INPUT
     14: MOBILE_INPUT
-    18: UNITY_POST_PROCESSING_STACK_V2
-    19: UNITY_POST_PROCESSING_STACK_V2
     20: MOBILE_INPUT
-    21: UNITY_POST_PROCESSING_STACK_V2
-    23: UNITY_POST_PROCESSING_STACK_V2
-    25: UNITY_POST_PROCESSING_STACK_V2
-    26: UNITY_POST_PROCESSING_STACK_V2
-    27: UNITY_POST_PROCESSING_STACK_V2
   platformArchitecture:
     iOS: 2
   scriptingBackend:
@@ -636,9 +640,7 @@ PlayerSettings:
     Standalone: 0
     WebGL: 1
     iOS: 1
-  il2cppCompilerConfiguration: {}
   incrementalIl2cppBuild: {}
-  allowUnsafeCode: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 0
   apiCompatibilityLevelPerPlatform: {}
@@ -654,6 +656,7 @@ PlayerSettings:
   metroApplicationDescription: sdkproject
   wsaImages: {}
   metroTileShortName: 
+  metroCommandLineArgsFile: 
   metroTileShowName: 0
   metroMediumTileShowName: 0
   metroLargeTileShowName: 0
@@ -669,6 +672,14 @@ PlayerSettings:
   metroFTAFileTypes: []
   metroProtocolName: 
   metroCompilationOverrides: 1
+  tizenProductDescription: 
+  tizenProductURL: 
+  tizenSigningProfileName: 
+  tizenGPSPermissions: 0
+  tizenMicrophonePermissions: 0
+  tizenDeploymentTarget: 
+  tizenDeploymentTargetType: -1
+  tizenMinOSVersion: 1
   n3dsUseExtSaveData: 0
   n3dsCompressStaticMem: 1
   n3dsExtSaveDataNumber: 0x12345
@@ -689,7 +700,6 @@ PlayerSettings:
   XboxOneGameOsOverridePath: 
   XboxOnePackagingOverridePath: 
   XboxOneAppManifestOverridePath: 
-  XboxOneVersion: 1.0.0.0
   XboxOnePackageEncryption: 0
   XboxOnePackageUpdateGranularity: 2
   XboxOneDescription: 
@@ -722,8 +732,8 @@ PlayerSettings:
   facebookSdkVersion: 7.9.4
   apiCompatibilityLevel: 2
   cloudProjectId: f183eef4-72bf-420c-80e0-aaadeab22f30
-  projectName: Baran Viewer
-  organizationId: baran-kahyao-lu
+  projectName: Mapbox Unity SDK
+  organizationId: mapbox-inc
   cloudEnabled: 0
   enableNativePlatformBackendsForNewInputSystem: 0
   disableOldInputManagerSupport: 0

--- a/sdkproject/ProjectSettings/ProjectSettings.asset
+++ b/sdkproject/ProjectSettings/ProjectSettings.asset
@@ -126,7 +126,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.0.0
+  bundleVersion: 2.0.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
**Related issue**

Fixes issue where saving scripts while in preview or runtime breaks serialization.

**Description of changes**

- Added EditorHelper.OnScriptsReloaded(), which listens for [UnityEditor.Callbacks.DidReloadScripts]
- OnScriptsReloaded checks if Application.isEditor, then gets reference to AbstractMap, gets all UnityTile child components, and destroys their game objects. If application is playing, it calls  AbstractMap.DisableEditorPreview() and abstractMap.ForceRestartMap(), which calls abstractMap.Awake and Start. If application is in Editor Preview mode, it disables and enables editor preview, redrawing the map.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
