### PR TITLE
Serialize tile dictionary

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
+++ b/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
@@ -287,7 +287,7 @@ Prefab:
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000015258789
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114731470950229392, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -587,26 +587,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _initializeOnStart: 1
   _options:
     locationOptions:
       latitudeLongitude: 0,0
       zoom: 3
     extentOptions:
       extentType: 3
-      cameraBoundsOptions:
-        camera: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
-      rangeAroundCenterOptions:
-        west: 1
-        north: 1
-        east: 1
-        south: 1
-      rangeAroundTransformOptions:
-        targetTransform: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
+      defaultExtents:
+        cameraBoundsOptions:
+          camera: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
+        rangeAroundCenterOptions:
+          west: 1
+          north: 1
+          east: 1
+          south: 1
+        rangeAroundTransformOptions:
+          targetTransform: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
     placementOptions:
       placementType: 1
       snapMapToZero: 0
@@ -615,13 +615,14 @@ MonoBehaviour:
       unityTileSize: 100
     loadingTexture: {fileID: 2800000, guid: e2896a92727704803a9c422b043eae89, type: 3}
     tileMaterial: {fileID: 2100000, guid: b9f23e9bce724fa4daac57ecded470b8, type: 2}
+  _initializeOnStart: 1
   _imagery:
     _layerProperty:
       sourceType: 4
       sourceOptions:
         isActive: 1
         layerSource:
-          Name: Streets
+          Name: Satellite
           Id: mapbox.satellite
           Modified: 
           UserName: 
@@ -641,8 +642,9 @@ MonoBehaviour:
           UserName: 
       elevationLayerType: 3
       requiredOptions:
-        addCollider: 0
         exaggerationFactor: 1
+      colliderOptions:
+        addCollider: 0
       modificationOptions:
         sampleCount: 10
         useRelativeHeight: 1
@@ -679,6 +681,7 @@ MonoBehaviour:
       vectorSubLayers: []
       locationPrefabList: []
   _tileProvider: {fileID: 1461465689}
+  IsPreviewEnabled: 0
 --- !u!4 &1461465688
 Transform:
   m_ObjectHideFlags: 0
@@ -750,7 +753,7 @@ MonoBehaviour:
   OnTileError:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mapbox.Unity.Map.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
+    m_TypeName: Mapbox.Unity.Map.TileProviders.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1951800002
 Prefab:

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -13,4 +13,10 @@
 		public Texture2D loadingTexture = null;
 		public Material tileMaterial = null;
 	}
+
+	[Serializable]
+	public class EditorPreviewOptions : MapboxDataProperty
+	{
+		public bool isPreviewEnabled = false;
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -18,6 +18,5 @@
 	public class EditorPreviewOptions : MapboxDataProperty
 	{
 		public bool isPreviewEnabled = false;
-		public bool wasPreviewDisabledFromOnEnable = false;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -18,5 +18,6 @@
 	public class EditorPreviewOptions : MapboxDataProperty
 	{
 		public bool isPreviewEnabled = false;
+		public bool wasPreviewDisabledFromOnEnable = false;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -20,22 +20,22 @@
 		[UnityEditor.Callbacks.DidReloadScripts]
 		private static void OnScriptsReloaded()
 		{
-			AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
-
-			if(abstractMap == null)
+			if (Application.isEditor)
 			{
-				return;
-			}
+				AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
 
-			UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
+				if(abstractMap == null)
+				{
+					return;
+				}
 
-			for (int i = 0; i < unityTiles.Length; i++)
-			{
-				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
-			}
+				UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
 
-			if(Application.isEditor)
-			{
+				for (int i = 0; i < unityTiles.Length; i++)
+				{
+					UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
+				}
+
 				if (EditorApplication.isPlaying)
 				{
 					abstractMap.DisableEditorPreview();

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -34,9 +34,18 @@
 				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
 			}
 
-			if(Application.isEditor && EditorApplication.isPlaying)
+			if(Application.isEditor)
 			{
-				EditorApplication.isPlaying = false;
+				if (EditorApplication.isPlaying)
+				{
+					EditorApplication.isPlaying = false;
+					return;
+				}
+				if (abstractMap.PreviewOptions.wasPreviewDisabledFromOnEnable)
+				{
+					abstractMap.EnableEditorPreview();
+					abstractMap.PreviewOptions.isPreviewEnabled = true;
+				}
 			}
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -17,15 +17,28 @@
 	public static class EditorHelper
 	{
 
+
 		[UnityEditor.Callbacks.DidReloadScripts]
 		private static void OnScriptsReloaded()
 		{
 			if (Application.isEditor)
 			{
+				
 				AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
 
-				if(abstractMap == null)
+				if(abstractMap == null) 
 				{
+					return;
+				}
+				//we DO NOT want to reload the map when the user first presses the play button, but
+				//OnScriptsReloaded will get called when the user first hits play, so....
+				//...
+				//if we are in play or about to be in play and late update has not yet been called,
+				//then we should do nothing here, as we know that OnScriptsReloaded was called from 
+				//pressing the play button and not from a script reload during a play session...
+				if (EditorApplication.isPlayingOrWillChangePlaymode && !abstractMap.LateUpdateWasCalled)
+				{
+					Debug.Log("Play just started, do not reload anything...");
 					return;
 				}
 
@@ -38,17 +51,21 @@
 
 				if (EditorApplication.isPlaying)
 				{
+					Debug.Log("Reload PREVIEW mode");
 					abstractMap.DisableEditorPreview();
 					abstractMap.ForceRestartMap();
 					return;
 				}
+
 				if (abstractMap.PreviewOptions.isPreviewEnabled == true)
 				{
+					Debug.Log("Reload PLAY mode");
 					abstractMap.DisableEditorPreview();
 					abstractMap.EnableEditorPreview();
 				}
 			}
 		}
+
 
 		public static void CheckForModifiedProperty<T>(SerializedProperty property, T targetObject, bool forceHasChanged = false)
 		{

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -51,15 +51,16 @@
 
 				if (EditorApplication.isPlaying)
 				{
-					Debug.Log("Reload PREVIEW mode");
+					Debug.Log("Reload PLAY mode");
 					abstractMap.DisableEditorPreview();
 					abstractMap.ForceRestartMap();
 					return;
 				}
 
+
 				if (abstractMap.PreviewOptions.isPreviewEnabled == true)
 				{
-					Debug.Log("Reload PLAY mode");
+					Debug.Log("Reload PREVIEW mode");
 					abstractMap.DisableEditorPreview();
 					abstractMap.EnableEditorPreview();
 				}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -38,13 +38,14 @@
 			{
 				if (EditorApplication.isPlaying)
 				{
-					EditorApplication.isPlaying = false;
+					abstractMap.DisableEditorPreview();
+					abstractMap.ForceRestartMap();
 					return;
 				}
-				if (abstractMap.PreviewOptions.wasPreviewDisabledFromOnEnable)
+				if (abstractMap.PreviewOptions.isPreviewEnabled == true)
 				{
+					abstractMap.DisableEditorPreview();
 					abstractMap.EnableEditorPreview();
-					abstractMap.PreviewOptions.isPreviewEnabled = true;
 				}
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -7,6 +7,8 @@
 	using System.Linq;
 	using System.Reflection;
 	using Mapbox.Unity.Map;
+	using Mapbox.Unity.MeshGeneration.Data;
+
 	/// <summary>
 	/// EditorHelper class provides methods for working with serialzed properties.
 	/// Methods in this class are based on the spacepuppy-unity-framework, available at the url below.
@@ -14,6 +16,30 @@
 	/// </summary>
 	public static class EditorHelper
 	{
+
+		[UnityEditor.Callbacks.DidReloadScripts]
+		private static void OnScriptsReloaded()
+		{
+			AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
+
+			if(abstractMap == null)
+			{
+				return;
+			}
+
+			UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
+
+			for (int i = 0; i < unityTiles.Length; i++)
+			{
+				UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
+			}
+
+			if(Application.isEditor && EditorApplication.isPlaying)
+			{
+				EditorApplication.isPlaying = false;
+			}
+		}
+
 		public static void CheckForModifiedProperty<T>(SerializedProperty property, T targetObject, bool forceHasChanged = false)
 		{
 			MapboxDataProperty targetObjectAsDataProperty = GetMapboxDataPropertyObject(targetObject);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -104,7 +104,8 @@
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.Space();
 
-			var prevProp = serializedObject.FindProperty("IsPreviewEnabled");
+			var previewOptions = serializedObject.FindProperty("_previewOptions");
+			var prevProp = previewOptions.FindPropertyRelative("isPreviewEnabled");
 			var prev = prevProp.boolValue;
 
 			Color guiColor = GUI.color;

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -430,13 +430,6 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			if (_previewOptions.isPreviewEnabled == true)
-			{
-				DisableEditorPreview();
-				_previewOptions.wasPreviewDisabledFromOnEnable = true;
-			}
-			_previewOptions.isPreviewEnabled = false;
-
 			if (_options.tileMaterial == null)
 			{
 				_options.tileMaterial = new Material(Shader.Find("Standard"));
@@ -450,14 +443,20 @@ namespace Mapbox.Unity.Map
 
 		protected virtual void Awake()
 		{
-			// Setup a visualizer to get a "Starter" map.
+			
 			foreach (Transform tr in transform)
 			{
 				Destroy(tr.gameObject);
 			}
 
+			// Setup a visualizer to get a "Starter" map.
 			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
-			_previewOptions.wasPreviewDisabledFromOnEnable = false;
+				
+			if (_previewOptions.isPreviewEnabled == true)
+			{
+				DisableEditorPreview();
+				_previewOptions.isPreviewEnabled = false;
+			}
 		}
 
 		// Use this for initialization
@@ -493,7 +492,6 @@ namespace Mapbox.Unity.Map
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
-			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 			if (OnEditorPreviewEnabled != null)
 			{
 				OnEditorPreviewEnabled();
@@ -502,7 +500,6 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			//_mapVisualizer.ClearActiveTileKeyValueLists();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				TileProvider.Destroy();
@@ -519,6 +516,12 @@ namespace Mapbox.Unity.Map
 			{
 				OnEditorPreviewDisabled();
 			}
+		}
+
+		public void ForceRestartMap()
+		{
+			Awake();
+			Start();
 		}
 
 		protected IEnumerator SetupAccess()

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap
+	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
 	{
 		#region Private Fields
 
@@ -33,6 +33,7 @@ namespace Mapbox.Unity.Map
 		[SerializeField] protected VectorLayer _vectorData = new VectorLayer();
 		[SerializeField] protected AbstractTileProvider _tileProvider;
 		[SerializeField] protected HashSet<UnwrappedTileId> _currentExtent;
+		[SerializeField] protected EditorPreviewOptions _previewOptions = new EditorPreviewOptions();
 
 		protected AbstractMapVisualizer _mapVisualizer;
 		protected float _unityTileSize = 1;
@@ -46,7 +47,7 @@ namespace Mapbox.Unity.Map
 		#endregion
 
 		#region Properties
-		public bool IsPreviewEnabled = false;
+		//public bool IsPreviewEnabled = false;
 
 		public AbstractMapVisualizer MapVisualizer
 		{
@@ -422,7 +423,11 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			IsPreviewEnabled = false;
+			if (_previewOptions.isPreviewEnabled == true)
+			{
+				DisableEditorPreview();
+			}
+			_previewOptions.isPreviewEnabled = false;
 
 			if (_options.tileMaterial == null)
 			{
@@ -459,6 +464,23 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		private void EnableDisablePreview(object sender, EventArgs e)
+		{
+			if (!Application.isPlaying)
+			{
+				if (_previewOptions.isPreviewEnabled)
+				{
+					Debug.Log("Preview Enabled");
+					EnableEditorPreview();
+				}
+				else
+				{
+					Debug.Log("Preview Disbaled");
+					DisableEditorPreview();
+				}
+			}
+		}
+
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
@@ -470,7 +492,11 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			TileProvider = null;
+			if (_options.extentOptions.extentType != MapExtentType.Custom)
+			{
+				TileProvider.Destroy();
+				TileProvider = null;
+			}
 			_imagery.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_terrain.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_vectorData.SubLayerRemoved -= OnVectorDataSubLayerRemoved;
@@ -698,12 +724,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
-									TileProvider = new QuadTreeTileProvider();
+									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new QuadTreeTileProvider();
+								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 							}
 							break;
 						}
@@ -713,12 +739,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
-									TileProvider = new RangeTileProvider();
+									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeTileProvider();
+								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 							break;
 						}
@@ -728,12 +754,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
-									TileProvider = new RangeAroundTransformTileProvider();
+									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeAroundTransformTileProvider();
+								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 							}
 							break;
 						}
@@ -1074,6 +1100,7 @@ namespace Mapbox.Unity.Map
 			_options.scalingOptions.unityTileSize = tileSizeInUnityUnits;
 			_options.scalingOptions.HasChanged = true;
 		}
+
 		#endregion
 
 		#region Events

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
+	public class AbstractMap : MonoBehaviour, IMap
 	{
 		#region Private Fields
 
@@ -47,40 +47,6 @@ namespace Mapbox.Unity.Map
 		#endregion
 
 		#region Properties
-		//public bool IsPreviewEnabled = false;
-
-		public void OnBeforeSerialize()
-		{
-			if (_mapVisualizer == null)
-			{
-				return;
-			}
-			_mapVisualizer.SerializeActiveTileDictionary();
-			//Debug.Log("OnBeforeSerialize");
-			//_keys.Clear();
-			//_values.Clear();
-
-			//foreach (var kvp in _myDictionary)
-			//{
-			//	_keys.Add(kvp.Key);
-			//	_values.Add(kvp.Value);
-			//}
-		}
-
-		public void OnAfterDeserialize()
-		{
-			//Debug.Log("OnAfterDeserialize");
-
-			if(_mapVisualizer == null)
-			{
-				return;
-			}
-			_mapVisualizer.DeserializeActiveTileDictionary();
-			//_myDictionary = new Dictionary<int, string>();
-
-			//for (int i = 0; i != Math.Min(_keys.Count, _values.Count); i++)
-				//_myDictionary.Add(_keys[i], _values[i]);
-		}
 
 		public AbstractMapVisualizer MapVisualizer
 		{
@@ -497,6 +463,12 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		public void RestartMapFromScriptReload()
+		{
+			Awake();
+			Start();
+		}
+
 		private void EnableDisablePreview(object sender, EventArgs e)
 		{
 			if (!Application.isPlaying)
@@ -525,6 +497,7 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
+			//_mapVisualizer.ClearActiveTileKeyValueLists();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				TileProvider.Destroy();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -49,6 +49,39 @@ namespace Mapbox.Unity.Map
 		#region Properties
 		//public bool IsPreviewEnabled = false;
 
+		public void OnBeforeSerialize()
+		{
+			if (_mapVisualizer == null)
+			{
+				return;
+			}
+			_mapVisualizer.SerializeActiveTileDictionary();
+			//Debug.Log("OnBeforeSerialize");
+			//_keys.Clear();
+			//_values.Clear();
+
+			//foreach (var kvp in _myDictionary)
+			//{
+			//	_keys.Add(kvp.Key);
+			//	_values.Add(kvp.Value);
+			//}
+		}
+
+		public void OnAfterDeserialize()
+		{
+			//Debug.Log("OnAfterDeserialize");
+
+			if(_mapVisualizer == null)
+			{
+				return;
+			}
+			_mapVisualizer.DeserializeActiveTileDictionary();
+			//_myDictionary = new Dictionary<int, string>();
+
+			//for (int i = 0; i != Math.Min(_keys.Count, _values.Count); i++)
+				//_myDictionary.Add(_keys[i], _values[i]);
+		}
+
 		public AbstractMapVisualizer MapVisualizer
 		{
 			get

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -80,6 +80,14 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		public EditorPreviewOptions PreviewOptions
+		{
+			get
+			{
+				return _previewOptions;
+			}
+		}
+
 		/// <summary>
 		/// The map options.
 		/// Options to control the behaviour of the map like location,extent, scale and placement.
@@ -425,6 +433,7 @@ namespace Mapbox.Unity.Map
 			if (_previewOptions.isPreviewEnabled == true)
 			{
 				DisableEditorPreview();
+				_previewOptions.wasPreviewDisabledFromOnEnable = true;
 			}
 			_previewOptions.isPreviewEnabled = false;
 
@@ -448,6 +457,7 @@ namespace Mapbox.Unity.Map
 			}
 
 			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 		}
 
 		// Use this for initialization
@@ -461,12 +471,6 @@ namespace Mapbox.Unity.Map
 					SetUpMap();
 				}
 			}
-		}
-
-		public void RestartMapFromScriptReload()
-		{
-			Awake();
-			Start();
 		}
 
 		private void EnableDisablePreview(object sender, EventArgs e)
@@ -489,6 +493,7 @@ namespace Mapbox.Unity.Map
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
+			_previewOptions.wasPreviewDisabledFromOnEnable = false;
 			if (OnEditorPreviewEnabled != null)
 			{
 				OnEditorPreviewEnabled();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -496,6 +496,21 @@ namespace Mapbox.Unity.Map
 		private void OnApplicationQuit()
 		{
 			_lateUpdateWasCalled = false;
+			if (_options.extentOptions.extentType != MapExtentType.Custom)
+			{
+				AbstractTileProvider tileProvider = GetComponent<AbstractTileProvider>();
+				if (tileProvider != null)
+				{
+					if (Application.isPlaying)
+					{
+						Destroy(tileProvider);
+					}
+					else
+					{
+						DestroyImmediate(tileProvider);
+					}
+				}
+			}
 		}
 
 		private void EnableDisablePreview(object sender, EventArgs e)
@@ -523,7 +538,6 @@ namespace Mapbox.Unity.Map
 				OnEditorPreviewEnabled();
 			}
 		}
-
 
 		public void DisableEditorPreview()
 		{
@@ -765,8 +779,16 @@ namespace Mapbox.Unity.Map
 				if(tileProvider != null)
 				{
 					Debug.Log("The is already a tile provider COMPONENT attached to this gameobject");
-					Destroy(tileProvider);
+					if(Application.isPlaying)
+					{
+						Destroy(tileProvider);
+					}
+					else
+					{
+						DestroyImmediate(tileProvider);
+					}
 				}
+
 				ITileProviderOptions tileProviderOptions = _options.extentOptions.GetTileProviderOptions();
 				// Setup tileprovider based on type.
 				switch (_options.extentOptions.extentType)

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
+	public class AbstractMap : MonoBehaviour, IMap
 	{
 		#region Private Fields
 
@@ -711,7 +711,6 @@ namespace Mapbox.Unity.Map
 
 		private void SetTileProvider()
 		{
-			//TileProvider = GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				ITileProviderOptions tileProviderOptions = _options.extentOptions.GetTileProviderOptions();
@@ -724,6 +723,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
@@ -739,6 +739,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
@@ -754,6 +755,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -34,6 +34,9 @@ namespace Mapbox.Unity.Map
 		protected Queue<UnityTile> _inactiveTiles = new Queue<UnityTile>();
 		private int _counter;
 
+		public List<UnwrappedTileId> _activeTilesKeys = new List<UnwrappedTileId>();
+		public List<UnityTile> _activeTilesValues = new List<UnityTile>();
+
 		private ModuleState _state;
 		public ModuleState State
 		{
@@ -65,6 +68,41 @@ namespace Mapbox.Unity.Map
 		public UnityTile GetUnityTileFromUnwrappedTileId(UnwrappedTileId tileId)
 		{
 			return _activeTiles[tileId];
+		}
+
+		public void SerializeActiveTileDictionary()
+		{
+			Debug.Log("..");
+			if(_activeTiles == null || _activeTiles.Count == 0)
+			{
+				return;
+			}
+
+			int count = Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count);
+
+			if(_activeTiles.Count == count)
+			{
+				return;
+			}
+
+			Debug.Log("SerializeActiveTileDictionary");
+			_activeTilesKeys.Clear();
+			_activeTilesValues.Clear();
+
+			foreach (var kvp in _activeTiles)
+			{
+				_activeTilesKeys.Add(kvp.Key);
+				_activeTilesValues.Add(kvp.Value);
+			}
+		}
+
+		public void DeserializeActiveTileDictionary()
+		{
+			Debug.Log("DeserializeActiveTileDictionary");
+			_activeTiles = new Dictionary<UnwrappedTileId, UnityTile>();
+
+			for (int i = 0; i != Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count); i++)
+				_activeTiles.Add(_activeTilesKeys[i], _activeTilesValues[i]);
 		}
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -262,16 +262,17 @@ namespace Mapbox.Unity.Map
 		public void ClearMap()
 		{
 			UnregisterAllTiles();
-
-			foreach (var tileFactory in Factories)
+			if (Factories != null)
 			{
-				if (tileFactory != null)
+				foreach (var tileFactory in Factories)
 				{
-					tileFactory.Clear();
-					DestroyImmediate(tileFactory);
+					if (tileFactory != null)
+					{
+						tileFactory.Clear();
+						DestroyImmediate(tileFactory);
+					}
 				}
 			}
-
 			foreach (var tileId in _activeTiles.Keys.ToList())
 			{
 				_activeTiles[tileId].ClearAssets();

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -34,9 +34,6 @@ namespace Mapbox.Unity.Map
 		protected Queue<UnityTile> _inactiveTiles = new Queue<UnityTile>();
 		private int _counter;
 
-		public List<UnwrappedTileId> _activeTilesKeys = new List<UnwrappedTileId>();
-		public List<UnityTile> _activeTilesValues = new List<UnityTile>();
-
 		private ModuleState _state;
 		public ModuleState State
 		{
@@ -68,41 +65,6 @@ namespace Mapbox.Unity.Map
 		public UnityTile GetUnityTileFromUnwrappedTileId(UnwrappedTileId tileId)
 		{
 			return _activeTiles[tileId];
-		}
-
-		public void SerializeActiveTileDictionary()
-		{
-			Debug.Log("..");
-			if(_activeTiles == null || _activeTiles.Count == 0)
-			{
-				return;
-			}
-
-			int count = Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count);
-
-			if(_activeTiles.Count == count)
-			{
-				return;
-			}
-
-			Debug.Log("SerializeActiveTileDictionary");
-			_activeTilesKeys.Clear();
-			_activeTilesValues.Clear();
-
-			foreach (var kvp in _activeTiles)
-			{
-				_activeTilesKeys.Add(kvp.Key);
-				_activeTilesValues.Add(kvp.Value);
-			}
-		}
-
-		public void DeserializeActiveTileDictionary()
-		{
-			Debug.Log("DeserializeActiveTileDictionary");
-			_activeTiles = new Dictionary<UnwrappedTileId, UnityTile>();
-
-			for (int i = 0; i != Math.Min(_activeTilesKeys.Count, _activeTilesValues.Count); i++)
-				_activeTiles.Add(_activeTilesKeys[i], _activeTilesValues[i]);
 		}
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
@@ -12,7 +12,7 @@ namespace Mapbox.Unity.Map.TileProviders
 		public HashSet<UnwrappedTileId> activeTiles;
 	}
 
-	public abstract class AbstractTileProvider : ITileProvider
+	public abstract class AbstractTileProvider : MonoBehaviour, ITileProvider
 	{
 		public event EventHandler<ExtentArgs> ExtentChanged;
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -285,7 +285,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 				//reset image on null data
 				if (data == null)
 				{
-					MeshRenderer.material.mainTexture = null;
+					MeshRenderer.sharedMaterial.mainTexture = null;
 					return;
 				}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
@@ -29,12 +29,12 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 			}
 
 			if ((int)tile.ElevationType != (int)ElevationLayerType.GlobeTerrain ||
-			    tile.MeshFilter.mesh.vertexCount != RequiredVertexCount)
+				tile.MeshFilter.sharedMesh.vertexCount != RequiredVertexCount)
 			{
-				tile.MeshFilter.mesh.Clear();
+				tile.MeshFilter.sharedMesh.Clear();
 				tile.ElevationType = TileTerrainType.Globe;
 			}
-		
+
 			GenerateTerrainMesh(tile);
 		}
 
@@ -91,11 +91,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				}
 			}
 
-			tile.MeshFilter.mesh.SetVertices(verts);
-			tile.MeshFilter.mesh.SetTriangles(trilist, 0);
-			tile.MeshFilter.mesh.SetUVs(0, uvlist);
-			tile.MeshFilter.mesh.RecalculateBounds();
-			tile.MeshFilter.mesh.RecalculateNormals();
+			tile.MeshFilter.sharedMesh.SetVertices(verts);
+			tile.MeshFilter.sharedMesh.SetTriangles(trilist, 0);
+			tile.MeshFilter.sharedMesh.SetUVs(0, uvlist);
+			tile.MeshFilter.sharedMesh.RecalculateBounds();
+			tile.MeshFilter.sharedMesh.RecalculateNormals();
 
 			tile.transform.localPosition = Mapbox.Unity.Constants.Math.Vector3Zero;
 		}

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -84,7 +84,10 @@ namespace Mapbox.Unity.Map
 
 		public void UnbindAllEvents()
 		{
-			_vectorTileFactory.UnbindEvents();
+			if (_vectorTileFactory != null)
+			{
+				_vectorTileFactory.UnbindEvents();
+			}
 		}
 
 		public void UpdateFactorySettings()


### PR DESCRIPTION
**Related issue**

Fixes issue where saving scripts while in preview or runtime breaks serialization.

**Description of changes**

Added EditorHelper.OnScriptsReloaded(), which listens for [UnityEditor.Callbacks.DidReloadScripts]
OnScriptsReloaded checks if Application.isEditor, then gets reference to AbstractMap, gets all UnityTile child components, and destroys their game objects. If application is playing, it calls AbstractMap.DisableEditorPreview() and abstractMap.ForceRestartMap(), which calls abstractMap.Awake and Start. If application is in Editor Preview mode, it disables and enables editor preview, redrawing the map.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
