### PR TITLE
Custom tileprovider fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
+++ b/sdkproject/Assets/Mapbox/Examples/7_Globe/Globe.unity
@@ -287,7 +287,7 @@ Prefab:
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000015258789
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114731470950229392, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -587,26 +587,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _initializeOnStart: 1
   _options:
     locationOptions:
       latitudeLongitude: 0,0
       zoom: 3
     extentOptions:
       extentType: 3
-      cameraBoundsOptions:
-        camera: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
-      rangeAroundCenterOptions:
-        west: 1
-        north: 1
-        east: 1
-        south: 1
-      rangeAroundTransformOptions:
-        targetTransform: {fileID: 0}
-        visibleBuffer: 0
-        disposeBuffer: 0
+      defaultExtents:
+        cameraBoundsOptions:
+          camera: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
+        rangeAroundCenterOptions:
+          west: 1
+          north: 1
+          east: 1
+          south: 1
+        rangeAroundTransformOptions:
+          targetTransform: {fileID: 0}
+          visibleBuffer: 0
+          disposeBuffer: 0
     placementOptions:
       placementType: 1
       snapMapToZero: 0
@@ -615,13 +615,14 @@ MonoBehaviour:
       unityTileSize: 100
     loadingTexture: {fileID: 2800000, guid: e2896a92727704803a9c422b043eae89, type: 3}
     tileMaterial: {fileID: 2100000, guid: b9f23e9bce724fa4daac57ecded470b8, type: 2}
+  _initializeOnStart: 1
   _imagery:
     _layerProperty:
       sourceType: 4
       sourceOptions:
         isActive: 1
         layerSource:
-          Name: Streets
+          Name: Satellite
           Id: mapbox.satellite
           Modified: 
           UserName: 
@@ -641,8 +642,9 @@ MonoBehaviour:
           UserName: 
       elevationLayerType: 3
       requiredOptions:
-        addCollider: 0
         exaggerationFactor: 1
+      colliderOptions:
+        addCollider: 0
       modificationOptions:
         sampleCount: 10
         useRelativeHeight: 1
@@ -679,6 +681,7 @@ MonoBehaviour:
       vectorSubLayers: []
       locationPrefabList: []
   _tileProvider: {fileID: 1461465689}
+  IsPreviewEnabled: 0
 --- !u!4 &1461465688
 Transform:
   m_ObjectHideFlags: 0
@@ -750,7 +753,7 @@ MonoBehaviour:
   OnTileError:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mapbox.Unity.Map.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
+    m_TypeName: Mapbox.Unity.Map.TileProviders.TileErrorEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1951800002
 Prefab:

--- a/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/DataContainers/MapOptions.cs
@@ -13,4 +13,10 @@
 		public Texture2D loadingTexture = null;
 		public Material tileMaterial = null;
 	}
+
+	[Serializable]
+	public class EditorPreviewOptions : MapboxDataProperty
+	{
+		public bool isPreviewEnabled = false;
+	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -104,7 +104,8 @@
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.Space();
 
-			var prevProp = serializedObject.FindProperty("IsPreviewEnabled");
+			var previewOptions = serializedObject.FindProperty("_previewOptions");
+			var prevProp = previewOptions.FindPropertyRelative("isPreviewEnabled");
 			var prev = prevProp.boolValue;
 
 			Color guiColor = GUI.color;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CameraBoundsTileProviderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/CameraBoundsTileProviderOptionsDrawer.cs
@@ -11,11 +11,15 @@
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			var camera = property.FindPropertyRelative("camera");
-			EditorGUILayout.PropertyField(camera, new GUIContent
+			EditorGUI.PropertyField(position, camera, new GUIContent
 			{
 				text = camera.displayName,
 				tooltip = "Camera to control map extent."
-			}, GUILayout.Height(_lineHeight));
+			});
+		}
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return 1 * _lineHeight;
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/MapExtentOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/MapExtentOptionsDrawer.cs
@@ -54,12 +54,14 @@
 			switch (kind)
 			{
 				case MapExtentType.CameraBounds:
+					GUILayout.Space(_lineHeight);
 					EditorGUILayout.PropertyField(defaultExtentsProp.FindPropertyRelative("cameraBoundsOptions"), new GUIContent { text = "CameraOptions-" });
 					break;
 				case MapExtentType.RangeAroundCenter:
 					EditorGUILayout.PropertyField(defaultExtentsProp.FindPropertyRelative("rangeAroundCenterOptions"), new GUIContent { text = "RangeAroundCenter" });
 					break;
 				case MapExtentType.RangeAroundTransform:
+					GUILayout.Space(_lineHeight);
 					EditorGUILayout.PropertyField(defaultExtentsProp.FindPropertyRelative("rangeAroundTransformOptions"), new GUIContent { text = "RangeAroundTransform" });
 					break;
 				default:

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/RangeAroundTransformTileProviderOptionsDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/RangeAroundTransformTileProviderOptionsDrawer.cs
@@ -14,10 +14,15 @@
 			foreach (var item in property)
 			{
 				var subproperty = item as SerializedProperty;
-				EditorGUILayout.PropertyField(subproperty, true);
+				EditorGUI.PropertyField(position, subproperty, true);
 				position.height = lineHeight;
 				position.y += lineHeight;
 			}
+		}
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return 3 * lineHeight;
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap
+	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
 	{
 		#region Private Fields
 
@@ -33,6 +33,7 @@ namespace Mapbox.Unity.Map
 		[SerializeField] protected VectorLayer _vectorData = new VectorLayer();
 		[SerializeField] protected AbstractTileProvider _tileProvider;
 		[SerializeField] protected HashSet<UnwrappedTileId> _currentExtent;
+		[SerializeField] protected EditorPreviewOptions _previewOptions = new EditorPreviewOptions();
 
 		protected AbstractMapVisualizer _mapVisualizer;
 		protected float _unityTileSize = 1;
@@ -46,7 +47,7 @@ namespace Mapbox.Unity.Map
 		#endregion
 
 		#region Properties
-		public bool IsPreviewEnabled = false;
+		//public bool IsPreviewEnabled = false;
 
 		public AbstractMapVisualizer MapVisualizer
 		{
@@ -422,7 +423,11 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			IsPreviewEnabled = false;
+			if (_previewOptions.isPreviewEnabled == true)
+			{
+				DisableEditorPreview();
+			}
+			_previewOptions.isPreviewEnabled = false;
 
 			if (_options.tileMaterial == null)
 			{
@@ -459,6 +464,23 @@ namespace Mapbox.Unity.Map
 			}
 		}
 
+		private void EnableDisablePreview(object sender, EventArgs e)
+		{
+			if (!Application.isPlaying)
+			{
+				if (_previewOptions.isPreviewEnabled)
+				{
+					Debug.Log("Preview Enabled");
+					EnableEditorPreview();
+				}
+				else
+				{
+					Debug.Log("Preview Disbaled");
+					DisableEditorPreview();
+				}
+			}
+		}
+
 		public void EnableEditorPreview()
 		{
 			SetUpMap();
@@ -470,7 +492,11 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			TileProvider = null;
+			if (_options.extentOptions.extentType != MapExtentType.Custom)
+			{
+				TileProvider.Destroy();
+				TileProvider = null;
+			}
 			_imagery.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_terrain.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_vectorData.SubLayerRemoved -= OnVectorDataSubLayerRemoved;
@@ -698,12 +724,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
-									TileProvider = new QuadTreeTileProvider();
+									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new QuadTreeTileProvider();
+								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 							}
 							break;
 						}
@@ -713,12 +739,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
-									TileProvider = new RangeTileProvider();
+									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeTileProvider();
+								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 							break;
 						}
@@ -728,12 +754,12 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
-									TileProvider = new RangeAroundTransformTileProvider();
+									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = new RangeAroundTransformTileProvider();
+								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 							}
 							break;
 						}
@@ -1074,6 +1100,7 @@ namespace Mapbox.Unity.Map
 			_options.scalingOptions.unityTileSize = tileSizeInUnityUnits;
 			_options.scalingOptions.HasChanged = true;
 		}
+
 		#endregion
 
 		#region Events

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -22,7 +22,7 @@ namespace Mapbox.Unity.Map
 	/// Abstract map encapsulates the image, terrain and vector sources and provides a centralized interface to control the visualization of the map.
 	/// </summary>
 	[ExecuteInEditMode]
-	public class AbstractMap : MonoBehaviour, IMap, ISerializationCallbackReceiver
+	public class AbstractMap : MonoBehaviour, IMap
 	{
 		#region Private Fields
 
@@ -711,7 +711,6 @@ namespace Mapbox.Unity.Map
 
 		private void SetTileProvider()
 		{
-			//TileProvider = GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom)
 			{
 				ITileProviderOptions tileProviderOptions = _options.extentOptions.GetTileProviderOptions();
@@ -724,6 +723,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
 								}
 							}
@@ -739,6 +739,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeTileProvider>();
 								}
 							}
@@ -754,6 +755,7 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
+									TileProvider.Destroy();
 									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -262,16 +262,17 @@ namespace Mapbox.Unity.Map
 		public void ClearMap()
 		{
 			UnregisterAllTiles();
-
-			foreach (var tileFactory in Factories)
+			if (Factories != null)
 			{
-				if (tileFactory != null)
+				foreach (var tileFactory in Factories)
 				{
-					tileFactory.Clear();
-					DestroyImmediate(tileFactory);
+					if (tileFactory != null)
+					{
+						tileFactory.Clear();
+						DestroyImmediate(tileFactory);
+					}
 				}
 			}
-
 			foreach (var tileId in _activeTiles.Keys.ToList())
 			{
 				_activeTiles[tileId].ClearAssets();

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/AbstractTileProvider.cs
@@ -12,7 +12,7 @@ namespace Mapbox.Unity.Map.TileProviders
 		public HashSet<UnwrappedTileId> activeTiles;
 	}
 
-	public abstract class AbstractTileProvider : ITileProvider
+	public abstract class AbstractTileProvider : MonoBehaviour, ITileProvider
 	{
 		public event EventHandler<ExtentArgs> ExtentChanged;
 

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
@@ -13,7 +13,7 @@ namespace Mapbox.Unity.Map.TileProviders
 
 		private Plane _groundPlane;
 		private bool _shouldUpdate;
-		private CameraBoundsTileProviderOptions _cbtpOptions;
+		[SerializeField] private CameraBoundsTileProviderOptions _cbtpOptions;
 
 		//private List<UnwrappedTileId> _toRemove;
 		//private HashSet<UnwrappedTileId> _tilesToRequest;
@@ -36,7 +36,14 @@ namespace Mapbox.Unity.Map.TileProviders
 		{
 			_tiles = new HashSet<UnwrappedTileId>();
 			_canonicalTiles = new HashSet<CanonicalTileId>();
-			_cbtpOptions = (CameraBoundsTileProviderOptions)_options;
+			if (Options != null)
+			{
+				_cbtpOptions = (CameraBoundsTileProviderOptions)_options;
+			}
+			else
+			{
+				_cbtpOptions = new CameraBoundsTileProviderOptions();
+			}
 
 			if (_cbtpOptions.camera == null)
 			{
@@ -169,7 +176,7 @@ namespace Mapbox.Unity.Map.TileProviders
 
 			Vector2d hitPntSWGeoPos = new Vector2d(minLat, minLong);
 			Vector2d hitPntNEGeoPos = new Vector2d(maxLat, maxLong);
-			Vector2dBounds tileBounds = new Vector2dBounds(Conversions.LatLonToMeters(hitPntSWGeoPos), Conversions.LatLonToMeters(hitPntNEGeoPos));			// Bounds debugging.
+			Vector2dBounds tileBounds = new Vector2dBounds(Conversions.LatLonToMeters(hitPntSWGeoPos), Conversions.LatLonToMeters(hitPntNEGeoPos));         // Bounds debugging.
 #if UNITY_EDITOR
 			Debug.DrawLine(_cbtpOptions.camera.transform.position, _map.GeoToWorldPosition(hitPntSWGeoPos), Color.blue);
 			Debug.DrawLine(_cbtpOptions.camera.transform.position, _map.GeoToWorldPosition(hitPntNEGeoPos), Color.red);

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/RangeAroundTransformTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/RangeAroundTransformTileProvider.cs
@@ -6,7 +6,7 @@ namespace Mapbox.Unity.Map.TileProviders
 {
 	public class RangeAroundTransformTileProvider : AbstractTileProvider
 	{
-		private RangeAroundTransformTileProviderOptions _rangeTileProviderOptions;
+		[SerializeField] private RangeAroundTransformTileProviderOptions _rangeTileProviderOptions;
 
 		private bool _initialized = false;
 		private UnwrappedTileId _currentTile;
@@ -14,7 +14,14 @@ namespace Mapbox.Unity.Map.TileProviders
 
 		public override void OnInitialized()
 		{
-			_rangeTileProviderOptions = (RangeAroundTransformTileProviderOptions)Options;
+			if (Options != null)
+			{
+				_rangeTileProviderOptions = (RangeAroundTransformTileProviderOptions)Options;
+			}
+			else if (_rangeTileProviderOptions == null)
+			{
+				_rangeTileProviderOptions = new RangeAroundTransformTileProviderOptions();
+			}
 
 			if (_rangeTileProviderOptions.targetTransform == null)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/RangeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/RangeTileProvider.cs
@@ -29,7 +29,7 @@ namespace Mapbox.Unity.Map.TileProviders
 
 		public override void UpdateTileExtent()
 		{
-			if (!_initialized || Options == null)
+			if (!_initialized || _rangeTileProviderOptions == null)
 			{
 				return;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatSphereTerrainStrategy.cs
@@ -29,12 +29,12 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 			}
 
 			if ((int)tile.ElevationType != (int)ElevationLayerType.GlobeTerrain ||
-			    tile.MeshFilter.mesh.vertexCount != RequiredVertexCount)
+				tile.MeshFilter.sharedMesh.vertexCount != RequiredVertexCount)
 			{
-				tile.MeshFilter.mesh.Clear();
+				tile.MeshFilter.sharedMesh.Clear();
 				tile.ElevationType = TileTerrainType.Globe;
 			}
-		
+
 			GenerateTerrainMesh(tile);
 		}
 
@@ -91,11 +91,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				}
 			}
 
-			tile.MeshFilter.mesh.SetVertices(verts);
-			tile.MeshFilter.mesh.SetTriangles(trilist, 0);
-			tile.MeshFilter.mesh.SetUVs(0, uvlist);
-			tile.MeshFilter.mesh.RecalculateBounds();
-			tile.MeshFilter.mesh.RecalculateNormals();
+			tile.MeshFilter.sharedMesh.SetVertices(verts);
+			tile.MeshFilter.sharedMesh.SetTriangles(trilist, 0);
+			tile.MeshFilter.sharedMesh.SetUVs(0, uvlist);
+			tile.MeshFilter.sharedMesh.RecalculateBounds();
+			tile.MeshFilter.sharedMesh.RecalculateNormals();
 
 			tile.transform.localPosition = Mapbox.Unity.Constants.Math.Vector3Zero;
 		}

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -84,7 +84,10 @@ namespace Mapbox.Unity.Map
 
 		public void UnbindAllEvents()
 		{
-			_vectorTileFactory.UnbindEvents();
+			if (_vectorTileFactory != null)
+			{
+				_vectorTileFactory.UnbindEvents();
+			}
 		}
 
 		public void UpdateFactorySettings()


### PR DESCRIPTION

**Description of changes**
Revert TileProviders to Monobehaviours
Fix issue where adding default tile providers would not initialize if used as custom tile providers

To test - 
Switch `Extent Type` to `Custom` 
Add a default tile provider to the map. Drop this into the custom tileprovider UI. 
Enable preview/press play. 


**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
