### PR TITLE
Reloadscript serialization playmode fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -20,24 +20,15 @@
 		[UnityEditor.Callbacks.DidReloadScripts]
 		private static void OnScriptsReloaded()
 		{
-			Debug.Log("OnScriptsReloaded");
 			if (Application.isEditor)
 			{
-				Debug.Log("OnScriptsReloaded --> Step 1");
 				AbstractMap abstractMap = UnityEngine.Object.FindObjectOfType<AbstractMap>();
 
 				if (abstractMap == null)
 				{
 					return;
 				}
-				//we DO NOT want to reload the map when the user first presses the play button, but
-				//OnScriptsReloaded will get called when the user first hits play, so....
-				//...
-				//if we are in play or about to be in play and late update has not yet been called,
-				//then we should do nothing here, as we know that OnScriptsReloaded was called from 
-				//pressing the play button and not from a script reload during a play session...
 
-				Debug.Log("OnScriptsReloaded --> Step 2");
 				UnityTile[] unityTiles = abstractMap.GetComponentsInChildren<UnityTile>();
 
 				for (int i = 0; i < unityTiles.Length; i++)
@@ -47,29 +38,20 @@
 
 				if (EditorApplication.isPlaying)
 				{
-					Debug.Log("Restart Map mode");
 					abstractMap.RestartMap();
 					return;
 				}
-				Debug.Log("OnScriptsReloaded --> Step 3.0");
 				if (abstractMap.IsEditorPreviewEnabled == true)
 				{
-					Debug.Log("EditorPreview = true");
 					if (EditorApplication.isPlayingOrWillChangePlaymode)
 					{
-						//abstractMap.IsEditorPreviewEnabled = false;
-						//abstractMap.DestroyTileProvider();
-						Debug.Log("Play just started, do not reload anything.......");
 						return;
 					}
 					else
 					{
-						Debug.Log("Reload mode reset --> take 2");
-						//abstractMap.DisableEditorPreview();
-						abstractMap.ReEnablePreview = true;
-						//abstractMap.EnableEditorPreview();
+						abstractMap.DisableEditorPreview();
+						abstractMap.EnableEditorPreview();
 					}
-
 				}
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/EditorHelper.cs
@@ -45,14 +45,13 @@
 					UnityEngine.Object.DestroyImmediate(unityTiles[i].gameObject);
 				}
 
-				//if (EditorApplication.isPlaying)
-				//{
-				//	Debug.Log("Reload PREVIEW mode");
-				//	abstractMap.DisableEditorPreview();
-				//	abstractMap.ForceRestartMap();
-				//	return;
-				//}
-				Debug.Log("OnScriptsReloaded --> Step 3");
+				if (EditorApplication.isPlaying)
+				{
+					Debug.Log("Restart Map mode");
+					abstractMap.RestartMap();
+					return;
+				}
+				Debug.Log("OnScriptsReloaded --> Step 3.0");
 				if (abstractMap.IsEditorPreviewEnabled == true)
 				{
 					Debug.Log("EditorPreview = true");

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -160,20 +160,8 @@
 
 			if (!Application.isPlaying)
 			{
-				var test = serializedObject.FindProperty("ReEnablePreview");
-				if (test.boolValue == true)
-				{
-					((AbstractMap)serializedObject.targetObject).DisableEditorPreview();
-					((AbstractMap)serializedObject.targetObject).EnableEditorPreview();
-					((AbstractMap)serializedObject.targetObject).ReEnablePreview = false;
-				}
-			}
-
-			if (!Application.isPlaying)
-			{
 				if (prevProp.boolValue && !prev)
 				{
-					Debug.Log("Enable Preview button!!");
 					((AbstractMap)serializedObject.targetObject).EnableEditorPreview();
 				}
 				else if (prev && !prevProp.boolValue)

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -315,7 +315,7 @@ namespace Mapbox.Unity.Map
 		}
 
 		//Unity Update
-		private void Update()
+		protected virtual void Update()
 		{
 			if (TileProvider != null)
 			{
@@ -470,16 +470,7 @@ namespace Mapbox.Unity.Map
 		{
 			Debug.Log("Awake!!");
 
-			// Destroy any ghost game objects. 
-			foreach (Transform tr in transform)
-			{
-				Destroy(tr.gameObject);
-			}
-			//Destroy default tileproviders that might be orphaned due to serialization. 
-			DestroyTileProvider();
-
-			// Setup a visualizer to get a "Starter" map.
-			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+			MapOnAwakeRoutine();
 
 			if (_previewOptions.isPreviewEnabled == true)
 			{
@@ -499,6 +490,40 @@ namespace Mapbox.Unity.Map
 					SetUpMap();
 				}
 			}
+		}
+
+		private void MapOnAwakeRoutine()
+		{
+			// Destroy any ghost game objects. 
+			foreach (Transform tr in transform)
+			{
+				Destroy(tr.gameObject);
+			}
+			//Destroy default tileproviders that might be orphaned due to serialization. 
+			DestroyTileProvider();
+
+			// Setup a visualizer to get a "Starter" map.
+			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+		}
+
+
+		private void MapOnStartRoutine()
+		{
+			if (Application.isPlaying)
+			{
+				//StartCoroutine("SetupAccess");
+				if (_initializeOnStart)
+				{
+					SetUpMap();
+				}
+			}
+		}
+
+
+		public void RestartMap()
+		{
+			MapOnAwakeRoutine();
+			MapOnStartRoutine();
 		}
 
 		private void EnableDisablePreview(object sender, EventArgs e)

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -44,7 +44,6 @@ namespace Mapbox.Unity.Map
 		protected Vector2d _centerMercator;
 		protected float _worldRelativeScale;
 		protected Vector3 _mapScaleFactor;
-		public bool ReEnablePreview = false;
 		#endregion
 
 		#region Properties
@@ -436,8 +435,6 @@ namespace Mapbox.Unity.Map
 
 		private void OnEnable()
 		{
-			Debug.Log("On Enable");
-			//DestroyTileProvider();
 
 			if (_options.tileMaterial == null)
 			{
@@ -453,7 +450,6 @@ namespace Mapbox.Unity.Map
 		// TODO: implement IDisposable, instead?
 		protected virtual void OnDestroy()
 		{
-			Debug.Log("OnDestroy");
 			if (TileProvider != null)
 			{
 				TileProvider.ExtentChanged -= OnMapExtentChanged;
@@ -468,8 +464,6 @@ namespace Mapbox.Unity.Map
 
 		protected virtual void Awake()
 		{
-			Debug.Log("Awake!!");
-
 			MapOnAwakeRoutine();
 
 			if (_previewOptions.isPreviewEnabled == true)
@@ -545,8 +539,6 @@ namespace Mapbox.Unity.Map
 
 		public void EnableEditorPreview()
 		{
-			Debug.Log("Preview Enabled!!");
-
 			SetUpMap();
 			if (OnEditorPreviewEnabled != null)
 			{
@@ -556,8 +548,6 @@ namespace Mapbox.Unity.Map
 
 		public void DisableEditorPreview()
 		{
-			Debug.Log("Preview Disabled!!!!");
-
 			_imagery.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_terrain.UpdateLayer -= OnImageOrTerrainUpdateLayer;
 			_vectorData.SubLayerRemoved -= OnVectorDataSubLayerRemoved;
@@ -575,13 +565,9 @@ namespace Mapbox.Unity.Map
 
 		public void DestroyTileProvider()
 		{
-
 			var tileProvider = TileProvider ?? gameObject.GetComponent<AbstractTileProvider>();
-			string state = (_tileProvider == null) ? "NULL" : "NOT NULL";
-			Debug.Log("_tileProvider state --> " + state);
 			if (_options.extentOptions.extentType != MapExtentType.Custom && tileProvider != null)
 			{
-				Debug.Log("Tile Provider Destroyer!!!!!!!!!");
 				tileProvider.Destroy();
 			}
 		}
@@ -813,16 +799,11 @@ namespace Mapbox.Unity.Map
 						{
 							if (TileProvider != null)
 							{
-								//if (!(TileProvider is RangeTileProvider))
-								Debug.Log("TileProvider NOT NULL !!!");
-								{
-									TileProvider.Destroy();
-									TileProvider = gameObject.AddComponent<RangeTileProvider>();
-								}
+								TileProvider.Destroy();
+								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 							else
 							{
-								Debug.Log("TileProvider NULL");
 								TileProvider = gameObject.AddComponent<RangeTileProvider>();
 							}
 							break;

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs
@@ -8,12 +8,10 @@ public static class GameObjectExtensions
 	{
 		if (Application.isEditor && !Application.isPlaying)
 		{
-			Debug.Log("Destroy Immediate");
 			GameObject.DestroyImmediate(obj, deleteAsset);
 		}
 		else
 		{
-			Debug.Log("Destroy Delayed");
 			GameObject.Destroy(obj);
 		}
 	}


### PR DESCRIPTION

**Description of changes**

Fixes issue w/ broken map serialization during script reloads by destroying and redrawing map.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
