### PR TITLE
change vectorlayervisualizer not to unload assets 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -751,20 +751,12 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 				{
 					DestroyImmediate(mod);
 				}
-				else
-				{
-					Resources.UnloadAsset(mod);
-				}
 			}
 			foreach (var mod in _defaultStack.GoModifiers)
 			{
 				if (_coreModifiers.Contains(mod))
 				{
 					DestroyImmediate(mod);
-				}
-				else
-				{
-					Resources.UnloadAsset(mod);
 				}
 			}
 


### PR DESCRIPTION
issue;
- open traffic demo scene
- enable preview
- disable/enable a traffic layer
- now disable/enable another one, this time it won't reappear as expected

problem;
we're using `unload asset` on file based modifiers to prevent memory leak but in editor time, it unloads for good and it will be null second time.

fix;
I tried removing `unload asset` all together, it fixes the issue and I couldn't see any leak in the memory either.

@atripathi-mb @greglemonmapbox @jordy-isaac 