### PR TITLE
Tile provider destroy fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -560,15 +560,12 @@ namespace Mapbox.Unity.Map
 			var tileProvider = TileProvider ?? gameObject.GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom && tileProvider != null)
 			{
-				Debug.Log("Is Preview Enabled? : " + _previewOptions.isPreviewEnabled);
 				if(_previewOptions.isPreviewEnabled)
 				{
-					Debug.Log("Destroy");
 					tileProvider.Destroy();
 				}
 				else
 				{
-					Debug.Log("DelayDestroy");
 					tileProvider.DelayDestroy();
 				}
 				_tileProvider = null;

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -560,7 +560,17 @@ namespace Mapbox.Unity.Map
 			var tileProvider = TileProvider ?? gameObject.GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom && tileProvider != null)
 			{
-				tileProvider.Destroy();
+				Debug.Log("Is Preview Enabled? : " + _previewOptions.isPreviewEnabled);
+				if(_previewOptions.isPreviewEnabled)
+				{
+					Debug.Log("Destroy");
+					tileProvider.Destroy();
+				}
+				else
+				{
+					Debug.Log("DelayDestroy");
+					tileProvider.DelayDestroy();
+				}
 				_tileProvider = null;
 			}
 		}

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/GameObjectExtensions.cs
@@ -15,4 +15,15 @@ public static class GameObjectExtensions
 			GameObject.Destroy(obj);
 		}
 	}
+
+	public static void DelayDestroy(this Object obj, bool deleteAsset = false)
+	{
+		if (Application.isEditor && !Application.isPlaying)
+		{
+			if (obj != null)
+			{
+				UnityEditor.EditorApplication.delayCall += () => GameObject.DestroyImmediate(obj, deleteAsset);
+			}
+		}
+	}
 }


### PR DESCRIPTION
**Description of changes**

Fix test for MissingReferenceException on TileProvider, seen in Unity 2018.

- Added DelayDestroy to GameObjectExtensions, which adds `GameObject.DestroyImmediate(obj, deleteAsset);` to `UnityEditor.EditorApplication.delayCall` delegate, resulting in gameobject getting _destroyed immediately_ after the GUI finishes rendering.

- Changed AbstractMap.DestroyTileProvider to check preview state and call appropriate destroy method for TileProvider; Destroy if preview is enabled; DelayDestroy if not. This is necessary to prevent a second Tile Provider from being added during `Preview => Play`

PLEASE TEST IN UNITY 2017 AND 2018!

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
