### PR TITLE
[DNM] Updates URLs for API documentation

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -300,7 +300,7 @@
 - Ensure your `MapImageFactories` have the expected `Map Id`! We've updated the way Ids are serialized, and your old Ids may have been lost--sorry!
 
 ##### Memory/Performance
-- Added support for style-optimized vector tiles! [Read more here.](https://www.mapbox.com/api-documentation/#retrieve-tiles)
+- Added support for style-optimized vector tiles! [Read more here.](https://www.mapbox.com/api-documentation/maps/#request-style-optimized-tiles)
     - You will need to use the new `StyleOptimizedVectorTileFactory`.
     - This can result in far less data transfer/data processing.
 - Replaced Triangle.NET with `Earcut` which results if much faster geometry construction.

--- a/scope.md
+++ b/scope.md
@@ -2,13 +2,13 @@
 
 The goal of the Unity API is to make it easy for game developers to build beautiful location based games. The API should be flexible enough to allow creative developers to use location data in novel ways, but easy enough to prototype a game environment with a map in a couple minutes.
 
-The API will include a core C# library for requesting data from Mapbox APIS, and then a higher-level set of components designed to work specifically with Unity. 
+The API will include a core C# library for requesting data from Mapbox APIS, and then a higher-level set of components designed to work specifically with Unity.
 
 There are four parts to the Unity SDK: core API support, utilities, Unity components, and custom inspectors:
 
 ## Core API support
 
-The Unity SDK will provide an interface to the following [Mapbox web services](https://www.mapbox.com/api-documentation/). I separated services into two priority levels. Priority level 1 is the base level of support we need to release the Unity SDK. Priority level 2 features are those that would be necessary to make the SDK feel complete and up to par with our SDKs on other platforms. 
+The Unity SDK will provide an interface to the following [Mapbox web services](https://www.mapbox.com/api-documentation/). I separated services into two priority levels. Priority level 1 is the base level of support we need to release the Unity SDK. Priority level 2 features are those that would be necessary to make the SDK feel complete and up to par with our SDKs on other platforms.
 
 ### Vector tilesets
 _Priority level 1_
@@ -22,28 +22,28 @@ To support vector tileset resources, the SDK will need to:
 
 First version of vector tile support can leave the rendering implementation to the user of the SDK.
 
-Documentation: https://www.mapbox.com/api-documentation/#retrieve-tiles
+Documentation: https://www.mapbox.com/api-documentation/maps/#retrieve-tiles
 
 ### Raster tilesets
 _Priority level 2_
 
 Much of the work we do to support vector tiles will be applicable to raster tiles. The main difference between vector tiles and raster tiles is that raster tiles would need to be used as textures. We could also add support for 3D terrain meshes based on raster elevation data.
 
-Documentation: https://www.mapbox.com/api-documentation/#retrieve-tiles
+Documentation: https://www.mapbox.com/api-documentation/maps/#retrieve-tiles
 
 ### Static maps
 _Priority level 2_
 
 Make it easy for a developer to request and apply a map texture of a fixed size to a game object.
 
-Documentation: https://www.mapbox.com/api-documentation/#static
+Documentation: https://www.mapbox.com/api-documentation/maps/#static
 
 ### Datasets
 _Priority level 2_
 
 Provide methods for both requesting data from a dataset and for posting changes to a dataset based on game objects.
 
-Documentation: https://www.mapbox.com/api-documentation/#datasets
+Documentation: https://www.mapbox.com/api-documentation/maps/#datasets
 
 ### Geocoding
 _Priority level 1_
@@ -52,7 +52,7 @@ Provide methods for requesting and storing forward geocode and reverse geocode r
 
 Will use callback functions like `GetForwardGeocode(GeocoderOptions, callback())` where `GeocoderOptions` is an object that includes the geocode query and all options, and callback is a function that receives the geocode response object. The response object can be used to do things like position points on the map or fill a UI template with search results.
 
-Documentation: https://www.mapbox.com/api-documentation/#geocoding
+Documentation: https://www.mapbox.com/api-documentation/search/#geocoding
 
 ### Directions
 _Priority level 1_
@@ -61,14 +61,14 @@ Provide a method for requesting and storing directions results. Support all opti
 
 Will use callback functions like `GetDirections(DirectionsOptions, callback())` where `DirectionsOptions` is an object that includes the directions query and all options, and callback is a function that receives the directions response object. The response object can then be used to do things like build a path on the map or to fill a UI template with instructions.
 
-Documentation: https://www.mapbox.com/api-documentation/#directions
+Documentation: https://www.mapbox.com/api-documentation/navigation/#directions
 
 ### Map matching
 _Priority level 2_
 
-Provide a method for sending user location and getting a match back. Support all optional parameters. Useful for snapping user position to road path. 
+Provide a method for sending user location and getting a match back. Support all optional parameters. Useful for snapping user position to road path.
 
-Documentation: https://www.mapbox.com/api-documentation/#map-matching
+Documentation: https://www.mapbox.com/api-documentation/navigation/#map-matching
 
 ## Utilities
 _Priority level 1_

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Directions/Directions.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Directions/Directions.cs
@@ -13,7 +13,7 @@ namespace Mapbox.Directions
     using Mapbox.Utils.JsonConverters;
 
     /// <summary>
-    ///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/#directions">
+    ///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/navigation/#directions">
     ///     Mapbox Directions API</see>. The Mapbox Directions API will show you how to get where
     ///     you're going.
     /// </summary>

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Geocoding/Geocoder.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Geocoding/Geocoder.cs
@@ -13,7 +13,7 @@ namespace Mapbox.Geocoding
 	using Mapbox.Utils.JsonConverters;
 
 	/// <summary>
-	///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/#geocoding">
+	///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/search/#geocoding">
 	///     Mapbox Geocoding API</see>. The Geocoder does two things: geocoding and reverse geocoding.
 	/// </summary>
 	public sealed class Geocoder

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRasterTile.cs
@@ -10,7 +10,7 @@ namespace Mapbox.Map
 	///    A raster tile from the Mapbox Map API, a encoded image representing a geographic
 	///    bounding box. Usually JPEG or PNG encoded.
 	/// See <see cref="T:Mapbox.Map.RasterTile"/> for usage.
-    /// Read more about <see href="https://www.mapbox.com/api-documentation/pages/static_classic.html"> static classic maps </see>.
+    /// Read more about <see href="https://www.mapbox.com/api-documentation/legacy/static-classic/"> static classic maps </see>.
 	/// </summary>
 	public class ClassicRasterTile : RasterTile
 	{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRetinaRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRetinaRasterTile.cs
@@ -10,7 +10,7 @@ namespace Mapbox.Map
 	///    A retina-resolution raster tile from the Mapbox Map API, a encoded image representing a geographic
 	///    bounding box. Usually JPEG or PNG encoded.
 	/// Like <see cref="T:Mapbox.Map.ClassicRasterTile"/>, but higher resolution.
-    /// See <see href="https://www.mapbox.com/api-documentation/#retina"> retina documentation </see>.
+    /// See <see href="https://www.mapbox.com/api-documentation/#high-dpi-images"> retina documentation </see>.
 	/// </summary>
     public class ClassicRetinaRasterTile : ClassicRasterTile
 	{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RetinaRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RetinaRasterTile.cs
@@ -10,7 +10,7 @@ namespace Mapbox.Map
     /// A retin-resolution raster tile from the Mapbox Style API, an encoded image representing a geographic
     /// bounding box. Usually JPEG or PNG encoded.
     /// Like <see cref="T:Mapbox.Map.RasterTile"/>, but higher resolution.
-    /// See <see href="https://www.mapbox.com/api-documentation/#retina"> retina documentation </see>.
+    /// See <see href="https://www.mapbox.com/api-documentation/#high-dpi-images"> retina documentation </see>.
     /// </summary>
     public class RetinaRasterTile : RasterTile
     {

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatcher.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatcher.cs
@@ -13,7 +13,7 @@ namespace Mapbox.MapMatching
 	using Mapbox.Utils.JsonConverters;
 
 	/// <summary>
-	///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/#map-matching">
+	///     Wrapper around the <see href="https://www.mapbox.com/api-documentation/navigation/#map-matching">
 	///     Mapbox Map Matching API</see>.
 	/// </summary>
 	public class MapMatcher

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatchingParameters.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/MapMatching/MapMatchingParameters.cs
@@ -69,7 +69,7 @@ namespace Mapbox.MapMatching
 
 
 	/// <summary>
-	/// https://www.mapbox.com/api-documentation/#retrieve-directions
+	/// https://www.mapbox.com/api-documentation/navigation/#retrieve-directions
 	/// </summary>
 	public enum InstructionLanguages
 	{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
@@ -46,12 +46,12 @@ namespace Mapbox.Platform
 		private readonly string _accessToken;
 		private readonly object _lock = new object();
 
-		/// <summary>Length of rate-limiting interval in seconds. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Length of rate-limiting interval in seconds. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 #pragma warning disable 0414
 		private int? XRateLimitInterval;
-		/// <summary>Maximum number of requests you may make in the current interval before reaching the limit. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Maximum number of requests you may make in the current interval before reaching the limit. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		private long? XRateLimitLimit;
-		/// <summary>Timestamp of when the current interval will end and the ratelimit counter is reset. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Timestamp of when the current interval will end and the ratelimit counter is reset. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		private DateTime? XRateLimitReset;
 #pragma warning restore 0414
 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Response.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Response.cs
@@ -66,15 +66,15 @@ namespace Mapbox.Platform
 		public string ContentType;
 
 
-		/// <summary>Length of rate-limiting interval in seconds. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Length of rate-limiting interval in seconds. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		public int? XRateLimitInterval;
 
 
-		/// <summary>Maximum number of requests you may make in the current interval before reaching the limit. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Maximum number of requests you may make in the current interval before reaching the limit. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		public long? XRateLimitLimit;
 
 
-		/// <summary>Timestamp of when the current interval will end and the ratelimit counter is reset. https://www.mapbox.com/api-documentation/#rate-limits </summary>
+		/// <summary>Timestamp of when the current interval will end and the ratelimit counter is reset. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		public DateTime? XRateLimitReset;
 
 
@@ -133,7 +133,7 @@ namespace Mapbox.Platform
 			if (null == apiResponse) {
 				response.AddException(new Exception("No Reponse."));
 			} else {
-				// https://www.mapbox.com/api-documentation/#rate-limits
+				// https://www.mapbox.com/api-documentation/#rate-limit-headers
 				if (null != apiResponse.Headers) {
 					response.Headers = new Dictionary<string, string>();
 					for (int i = 0; i < apiResponse.Headers.Count; i++) {
@@ -200,7 +200,7 @@ namespace Mapbox.Platform
 			if (null == apiResponse) {
 				response.AddException(new Exception("No Reponse."));
 			} else {
-				// https://www.mapbox.com/api-documentation/#rate-limits
+				// https://www.mapbox.com/api-documentation/#rate-limit-headers
 				if (null != apiResponse.Headers) {
 					response.Headers = new Dictionary<string, string>();
 					foreach (var hdr in apiResponse.Headers) {

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxToken.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxToken.cs
@@ -8,7 +8,7 @@ namespace Mapbox.Tokens
 
 
 	/// <summary>
-	/// Mapbox Token: https://www.mapbox.com/api-documentation/#retrieve-a-token
+	/// Mapbox Token: https://www.mapbox.com/api-documentation/accounts/#retrieve-a-token
 	/// </summary>
 	public class MapboxToken
 	{
@@ -82,7 +82,7 @@ namespace Mapbox.Tokens
 
 	/// <summary>
 	/// Every token has a metadata object that contains information about the capabilities of the token.
-	/// https://www.mapbox.com/api-documentation/#the-token-metadata-object
+	/// https://www.mapbox.com/api-documentation/accounts/#token-metadata-object
 	/// </summary>
 	public class TokenMetadata
 	{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxTokenApi.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tokens/MapboxTokenApi.cs
@@ -42,7 +42,7 @@ namespace Mapbox.Tokens
 
 		// use internal FileSource without(!) passing access token from config into constructor
 		// otherwise access token would be appended to url twice
-		// https://www.mapbox.com/api-documentation/#retrieve-a-token
+		// https://www.mapbox.com/api-documentation/accounts/#retrieve-a-token
 		// if we should ever implement other API methods: creating, deleting, updating ... tokens
 		// we will need another FileSource with the token from the config
 		private FileSource _fs = new FileSource();

--- a/sdkproject/Assets/Mapbox/Examples/5_Playground/Scenes/RasterTile.unity
+++ b/sdkproject/Assets/Mapbox/Examples/5_Playground/Scenes/RasterTile.unity
@@ -160,8 +160,8 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.72794116, g: 0.72794116, b: 0.72794116, a: 1}
   m_RaycastTarget: 1
@@ -238,8 +238,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.1953125, g: 0.1953125, b: 0.1953125, a: 1}
   m_RaycastTarget: 1
@@ -349,8 +349,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.17165874, g: 0.9338235, b: 0.55536926, a: 1}
   m_RaycastTarget: 1
@@ -403,8 +403,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -420,8 +420,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -649,7 +649,7 @@ Prefab:
 
         See:
 
-        https://www.mapbox.com/help/define-style/ https://www.mapbox.com/api-documentation/#retrieve-raster-tiles-from-styles'
+        https://www.mapbox.com/help/define-style/ https://www.mapbox.com/api-documentation/maps/#retrieve-raster-tiles-from-styles'
       objectReference: {fileID: 0}
     - target: {fileID: 224857786874416376, guid: 98be219873e6d4dffb5949746f515a33,
         type: 2}
@@ -703,8 +703,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
@@ -779,8 +779,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.5808823, g: 0.5808823, b: 0.5808823, a: 1}
   m_RaycastTarget: 0
@@ -812,8 +812,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -1254083943, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_AspectMode: 2
   m_AspectRatio: 1
 --- !u!1 &424102027
@@ -862,8 +862,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -895,8 +895,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -1200242548, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ShowMaskGraphic: 0
 --- !u!1 &475058525
 GameObject:
@@ -942,8 +942,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1010,8 +1010,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -98529514, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1077,8 +1077,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
@@ -1151,8 +1151,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1226,8 +1226,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9bce9ff37f5964623a657f4003af54f2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &810754449
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1238,8 +1238,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 575553740, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_SelectOnUp: {fileID: 0}
@@ -1302,8 +1302,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.78676474, g: 0.78676474, b: 0.78676474, a: 1}
   m_RaycastTarget: 1
@@ -1375,8 +1375,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 853051423, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_SelectOnUp: {fileID: 0}
@@ -1430,8 +1430,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1480,8 +1480,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1077351063, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -1498,8 +1498,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 5
@@ -1597,8 +1597,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1367256648, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Content: {fileID: 50838416}
   m_Horizontal: 0
   m_Vertical: 1
@@ -1628,8 +1628,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1822,8 +1822,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 2109663825, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_SelectOnUp: {fileID: 0}
@@ -1905,8 +1905,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1985,8 +1985,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.23137257, g: 0.69803923, b: 0.81568635, a: 1}
   m_RaycastTarget: 1
@@ -2056,8 +2056,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -2061169968, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_SelectOnUp: {fileID: 0}
@@ -2102,8 +2102,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2172,8 +2172,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.21960786, g: 0.5294118, b: 0.74509805, a: 1}
   m_RaycastTarget: 1
@@ -2222,8 +2222,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: baa72cd3a86b44e2e9923f1bfb635675, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _searchLocation: {fileID: 810754448}
   _zoomSlider: {fileID: 1983756122}
   _stylesDropdown: {fileID: 857912881}
@@ -2321,8 +2321,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2391,8 +2391,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.6764706, g: 0.6764706, b: 0.6764706, a: 1}
   m_RaycastTarget: 1
@@ -2468,8 +2468,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2553,8 +2553,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
   m_RaycastTarget: 1
@@ -2609,8 +2609,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -113659843, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_SelectOnUp: {fileID: 0}
@@ -2695,8 +2695,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.21960786, g: 0.5294118, b: 0.74509805, a: 1}
   m_RaycastTarget: 1

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -301,7 +301,7 @@ namespace Mapbox.Unity
 
 		TileJSON _tileJson;
 		/// <summary>
-		/// Lazy TileJSON wrapper: https://www.mapbox.com/api-documentation/#retrieve-tilejson-metadata
+		/// Lazy TileJSON wrapper: https://www.mapbox.com/api-documentation/maps/#retrieve-tilejson-metadata
 		/// </summary>
 		public TileJSON TileJSON
 		{

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/IImageryLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/IImageryLayer.cs
@@ -9,7 +9,7 @@
 
 		/// <summary>
 		/// Sets the `Data Source` for the `IMAGE` component. This can be one of the
-		/// [Mapbox default styles](https://www.mapbox.com/api-documentation/#styles),
+		/// [Mapbox default styles](https://www.mapbox.com/api-documentation/maps/#styles),
 		/// or a custom style. The style url is set as the `Map ID`.
 		/// </summary>
 		/// <param name="imageSource">Source of imagery for map. Can be a Mapbox default, or custom style.</param>


### PR DESCRIPTION
🚧 Do not merge until API documentation changes land. 🚧

**Related issue**

Relates to https://github.com/mapbox/api-documentation/pull/590

**Description of changes**

This PR updates links to match the new URL structure. Redirects won't work since Fastly doesn't play nice with hash-based paths, so we're updating manually. 

**Reviewers**

@atripathi-mb 

cc @mapbox/docs 
