### PR TITLE
change abstract map script to create tile provider on another gameobject

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -560,7 +560,7 @@ namespace Mapbox.Unity.Map
 			var tileProvider = TileProvider ?? gameObject.GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom && tileProvider != null)
 			{
-				tileProvider.Destroy();
+				tileProvider.gameObject.Destroy();
 				_tileProvider = null;
 			}
 		}
@@ -773,13 +773,17 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
-									TileProvider.Destroy();
-									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
+									TileProvider.gameObject.Destroy();
+									var go = new GameObject();
+									go.transform.parent = transform;
+									TileProvider = go.AddComponent<QuadTreeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<QuadTreeTileProvider>();
 							}
 							break;
 						}
@@ -787,12 +791,16 @@ namespace Mapbox.Unity.Map
 						{
 							if (TileProvider != null)
 							{
-								TileProvider.Destroy();
-								TileProvider = gameObject.AddComponent<RangeTileProvider>();
+								TileProvider.gameObject.Destroy();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeTileProvider>();
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<RangeTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeTileProvider>();
 							}
 							break;
 						}
@@ -802,13 +810,17 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
-									TileProvider.Destroy();
-									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
+									TileProvider.gameObject.Destroy();
+									var go = new GameObject();
+									go.transform.parent = transform;
+									TileProvider = go.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeAroundTransformTileProvider>();
 							}
 							break;
 						}
@@ -929,7 +941,10 @@ namespace Mapbox.Unity.Map
 		{
 			SetTileProvider();
 			TileProvider.Initialize(this);
-			TileProvider.UpdateTileExtent();
+			if (IsEditorPreviewEnabled)
+			{
+				TileProvider.UpdateTileExtent();
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
the main problem with destruction of tile provider was that it was on the same gameobject and inspector/editor didn't like that (destroying script while rendering inspector).
delaycall solutions are risky because it introduces a delay with might have many sideeffects at this point and it's using unity editor library which wont work on builds.
So what I did was to change abstract map to create tileprovider script on another game object under itself. being on another gameobject&inspector, destroying the script doesn't cause any issues. only big-ish problem with this is, there's one another object in hierarchy to maintain now. I tested a few cases and it looks fine but we should be careful with cleaning methods for example because map only had tiles as children so far and now it's having a utility gameobject as well.

@atripathi-mb @greglemonmapbox @jordy-isaac 