### PR TITLE
Port obsolete www class to UnityWebRequest class.

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/StyleSearchWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/StyleSearchWindow.cs
@@ -8,6 +8,7 @@
 	using Mapbox.Unity.Utilities;
 	using Mapbox.Unity.Map;
 	using System.Collections;
+	using UnityEngine.Networking;
 
 	public class StyleSearchWindow : EditorWindow
 	{
@@ -149,6 +150,23 @@
 
 		IEnumerator ListStyles(string token)
 		{
+#if UNITY_2017_1_OR_NEWER
+			UnityWebRequest webRequest = new UnityWebRequest(Utils.Constants.BaseAPI + string.Format("styles/v1/{0}?access_token={1}", _username, token))
+			{
+				downloadHandler = new DownloadHandlerBuffer()
+			};
+			yield return webRequest.SendWebRequest();
+
+			while (!webRequest.isDone)
+			{
+				yield return 0;
+			}
+			var json = webRequest.downloadHandler.text;
+			if (!string.IsNullOrEmpty(json))
+			{
+				ParseResponse(json);
+			}
+#else
 			// "https://api.mapbox.com/styles/v1/{username}?access_token=your-access-token"
 			var www = new WWW(Utils.Constants.BaseAPI + string.Format("styles/v1/{0}?access_token={1}", _username, token));
 			while (!www.isDone)
@@ -160,6 +178,7 @@
 			{
 				ParseResponse(json);
 			}
+#endif
 		}
 
 		void ParseResponse(string json)

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -560,7 +560,7 @@ namespace Mapbox.Unity.Map
 			var tileProvider = TileProvider ?? gameObject.GetComponent<AbstractTileProvider>();
 			if (_options.extentOptions.extentType != MapExtentType.Custom && tileProvider != null)
 			{
-				tileProvider.Destroy();
+				tileProvider.gameObject.Destroy();
 				_tileProvider = null;
 			}
 		}
@@ -773,13 +773,17 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is QuadTreeTileProvider))
 								{
-									TileProvider.Destroy();
-									TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
+									TileProvider.gameObject.Destroy();
+									var go = new GameObject();
+									go.transform.parent = transform;
+									TileProvider = go.AddComponent<QuadTreeTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<QuadTreeTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<QuadTreeTileProvider>();
 							}
 							break;
 						}
@@ -787,12 +791,16 @@ namespace Mapbox.Unity.Map
 						{
 							if (TileProvider != null)
 							{
-								TileProvider.Destroy();
-								TileProvider = gameObject.AddComponent<RangeTileProvider>();
+								TileProvider.gameObject.Destroy();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeTileProvider>();
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<RangeTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeTileProvider>();
 							}
 							break;
 						}
@@ -802,13 +810,17 @@ namespace Mapbox.Unity.Map
 							{
 								if (!(TileProvider is RangeAroundTransformTileProvider))
 								{
-									TileProvider.Destroy();
-									TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
+									TileProvider.gameObject.Destroy();
+									var go = new GameObject();
+									go.transform.parent = transform;
+									TileProvider = go.AddComponent<RangeAroundTransformTileProvider>();
 								}
 							}
 							else
 							{
-								TileProvider = gameObject.AddComponent<RangeAroundTransformTileProvider>();
+								var go = new GameObject();
+								go.transform.parent = transform;
+								TileProvider = go.AddComponent<RangeAroundTransformTileProvider>();
 							}
 							break;
 						}
@@ -929,7 +941,10 @@ namespace Mapbox.Unity.Map
 		{
 			SetTileProvider();
 			TileProvider.Initialize(this);
-			TileProvider.UpdateTileExtent();
+			if (IsEditorPreviewEnabled)
+			{
+				TileProvider.UpdateTileExtent();
+			}
 		}
 
 		#endregion

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -724,20 +724,12 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 				{
 					DestroyImmediate(mod);
 				}
-				else
-				{
-					Resources.UnloadAsset(mod);
-				}
 			}
 			foreach (var mod in _defaultStack.GoModifiers)
 			{
 				if (_coreModifiers.Contains(mod))
 				{
 					DestroyImmediate(mod);
-				}
-				else
-				{
-					Resources.UnloadAsset(mod);
 				}
 			}
 

--- a/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryEditor.cs
@@ -9,6 +9,7 @@ namespace Mapbox.Unity.Telemetry
 	using UnityEngine;
 	using System.Text;
 	using UnityEditor;
+	using UnityEngine.Networking;
 
 	public class TelemetryEditor : ITelemetryLibrary
 	{
@@ -69,17 +70,33 @@ namespace Mapbox.Unity.Telemetry
 		IEnumerator PostWWW(string url, string bodyJsonString)
 		{
 			byte[] bodyRaw = Encoding.UTF8.GetBytes(bodyJsonString);
-			var headers = new Dictionary<string, string>();
-			headers.Add("Content-Type", "application/json");
-			headers.Add("user-agent", GetUserAgent());
 
-			var www = new WWW(url, bodyRaw, headers);
-			yield return www;
-			while (!www.isDone) { yield return null; }
+#if UNITY_2017_1_OR_NEWER
+			UnityWebRequest postRequest = new UnityWebRequest(url, "POST");
+			postRequest.SetRequestHeader("Content-Type", "application/json");
 
-			// www doesn't expose HTTP status code, relay on 'error' property
-			if (!string.IsNullOrEmpty(www.error))
+			postRequest.downloadHandler = new DownloadHandlerBuffer();
+			postRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+
+			yield return postRequest.SendWebRequest();
+
+			while (!postRequest.isDone) { yield return null; }
+
+			if (!postRequest.isNetworkError)
 			{
+#else
+				var headers = new Dictionary<string, string>();
+				headers.Add("Content-Type", "application/json");
+				headers.Add("user-agent", GetUserAgent());
+				var www = new WWW(url, bodyRaw, headers);
+				yield return www;
+
+				while (!www.isDone) { yield return null; }
+
+				// www doesn't expose HTTP status code, relay on 'error' property
+				if (!string.IsNullOrEmpty(www.error))
+				{
+#endif
 				PlayerPrefs.SetString(Constants.Path.TELEMETRY_TURNSTILE_LAST_TICKS_EDITOR_KEY, "0");
 			}
 			else

--- a/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryFallback.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryFallback.cs
@@ -7,6 +7,7 @@ namespace Mapbox.Unity.Telemetry
 	using Mapbox.Unity.Utilities;
 	using UnityEngine;
 	using System.Text;
+	using UnityEngine.Networking;
 
 	public class TelemetryFallback : ITelemetryLibrary
 	{
@@ -68,12 +69,22 @@ namespace Mapbox.Unity.Telemetry
 		IEnumerator PostWWW(string url, string bodyJsonString)
 		{
 			byte[] bodyRaw = Encoding.UTF8.GetBytes(bodyJsonString);
+
+#if UNITY_2017_1_OR_NEWER
+			UnityWebRequest postRequest = new UnityWebRequest(url, "POST");
+			postRequest.SetRequestHeader("Content-Type", "application/json");
+
+			postRequest.downloadHandler = new DownloadHandlerBuffer();
+			postRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+
+			yield return postRequest.SendWebRequest();
+#else
 			var headers = new Dictionary<string, string>();
 			headers.Add("Content-Type", "application/json");
 			headers.Add("user-agent", GetUserAgent());
-
 			var www = new WWW(url, bodyRaw, headers);
 			yield return www;
+#endif
 		}
 
 		static string GetUserAgent()

--- a/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryWebgl.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryWebgl.cs
@@ -7,6 +7,7 @@
 	using Mapbox.Unity.Utilities;
 	using UnityEngine;
 	using System.Text;
+	using UnityEngine.Networking;
 
 	public class TelemetryWebgl : ITelemetryLibrary
 	{
@@ -73,11 +74,21 @@
 		IEnumerator PostWWW(string url, string bodyJsonString)
 		{
 			byte[] bodyRaw = Encoding.UTF8.GetBytes(bodyJsonString);
+#if UNITY_2017_1_OR_NEWER
+			UnityWebRequest postRequest = new UnityWebRequest(url, "POST");
+			postRequest.SetRequestHeader("Content-Type", "application/json");
+
+			postRequest.downloadHandler = new DownloadHandlerBuffer();
+			postRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+
+			yield return postRequest.SendWebRequest();
+#else
 			var headers = new Dictionary<string, string>();
 			headers.Add("Content-Type", "application/json");
-
+			headers.Add("user-agent", GetUserAgent());
 			var www = new WWW(url, bodyRaw, headers);
 			yield return www;
+#endif
 		}
 
 		static string GetUserAgent()


### PR DESCRIPTION
**Description of changes**

With Unity 2018.3, Unity throws warnings for using the obsolete `www` class. Suggestion is to use the `UnityWebRequest` class instead. 

@BergWerkGIS Could you take a quick look at the changes and see if they look good?

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
