### PR TITLE
[DO NOT MERGE] - Spawn inside fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/ColliderModifier.cs
@@ -68,7 +68,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			var existingCollider = ve.GameObject.GetComponent<Collider>();
 			if (existingCollider != null)
 			{
-				existingCollider.Destroy();
+				DestroyImmediate(existingCollider);
 				if (_colliderStrategy != null)
 				{
 					_colliderStrategy.Reset();

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/GameObjectModifiers/SpawnInsideModifier.cs
@@ -52,9 +52,8 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 		public override void Run(VectorEntity ve, UnityTile tile)
 		{
 			_spawnedCount = 0;
-			var collider = ve.GameObject.GetComponent<Collider>();
-			var bounds = collider.bounds;
-			var center = bounds.center;
+			var bounds = ve.Mesh.bounds;
+			var center = ve.Transform.position + bounds.center;
 			center.y = 0;
 
 			var area = (int)(bounds.size.x * bounds.size.z);
@@ -63,7 +62,7 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 			{
 				var x = UnityEngine.Random.Range(-bounds.extents.x, bounds.extents.x);
 				var z = UnityEngine.Random.Range(-bounds.extents.z, bounds.extents.z);
-				var ray = new Ray(bounds.center + new Vector3(x, 100, z), Vector3.down * 2000);
+				var ray = new Ray(center + new Vector3(x, 100, z), Vector3.down * 2000);
 
 				RaycastHit hit;
 				if (Physics.Raycast(ray, out hit, 150, _layerMask))


### PR DESCRIPTION
change spawn inside modifier to use mesh bounds instead of collider bounds.

testing;
- open interactive styled vector map scene
- change it to use range around transform with a small (or 0) range.
- move target objects (destroy/create tiles) and observe parks being generated in new tiles. Tree/Bush objects should all be inside parks.

@atripathi-mb @greglemonmapbox 