### PR TITLE
Update site build for new publishing context

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -10,3 +10,8 @@ if [ ! -d "docfx" ]; then mkdir -p docfx && unzip -o docfx.zip -d docfx; fi
 #splitting in two steps works
 mono ./docfx/docfx.exe metadata ./documentation/docfx_project/docfx.json
 mono ./docfx/docfx.exe build ./documentation/docfx_project/docfx.json
+
+#Generate files that are necessary for Publisher to deploy the right files to the right place
+echo "subdomain: docs" > ./documentation/docfx_project/_site/.publisher.yml
+echo "version: v1\ndefaults:\n- publisher" > ./documentation/docfx_project/_site/.artifacts.yml
+echo "# No content needed" > ./documentation/docfx_project/_site/_config.yml

--- a/scripts/build.csx
+++ b/scripts/build.csx
@@ -223,8 +223,8 @@ if (!publishDocs) {
 			"git config user.name \"appveyor\"",
 			$"git commit -m \"pushed via [{originalCommit}] by [{commitAuthor}]\"",
 			$"git remote add origin https://{githubToken}@github.com/{repoName}.git",
-			"git checkout -b mb-pages",
-			"git push -f origin mb-pages"
+			"git checkout -b publisher-production",
+			"git push -f origin publisher-production"
 		});
 		foreach (var cmd in cmds) {
 			if (!RunCommand(cmd)) {


### PR DESCRIPTION
**Related issue**

Addresses #1248.

**Description of changes**

During the site build, generates files that are necessary to publish with the latest version of Publisher to the `docs.mapbox.com` domain and puts them in the website directory: `.artifacts.yml`, `.publisher.yml`, `_config.yml` (which tells Jekyll to just copy the whole directory). 

We're also switching the publishable branch referenced in CI from `mb-pages` to `publisher-production`.

After this change, we should be able to close #1248 by locally building the site then pushing the `./documentation/docfx_project/_site/` directory to the `publisher-production` branch.

**QA checklists**

After the site build, you should see the files mentioned above in `./documentation/docfx_project/_site/`.

**Reviewers**

@atripathi-mb for review, please. 

cc @mapbox/docs @mapbox/frontend-platform 
