### PR TITLE
Missing field fix

### DIFF
--- a/sdkproject/Assets/MapboxAR/Unity/Ar/Utilities/PlotRoute.cs
+++ b/sdkproject/Assets/MapboxAR/Unity/Ar/Utilities/PlotRoute.cs
@@ -29,7 +29,10 @@
 		int _currentIndex = 0;
 		float _sqDistance;
 		Vector3 _lastPosition;
-
+#if !UNITY_EDITOR
+		bool _isStable = false;
+#endif
+		
 		void Awake()
 		{
 			// HACK: this needs to move somewhere else (marshal).


### PR DESCRIPTION
we removed this field recently because unity was poping `unused field` warnings but turns out it's used in ifdef block for builds.
I readded the field, instead of removing the usage in the ifdef block ,even though it looks totally useless, just to be safe.

@atripathi-mb @greglemonmapbox 