### PR TITLE
Update TelemetryAndroid.cs

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryAndroid.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryAndroid.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_ANDROID
+﻿#if !UNITY_EDITOR && UNITY_ANDROID
 namespace Mapbox.Unity.Telemetry
 {
 	using UnityEngine;


### PR DESCRIPTION
Update to the preprocessor platform check in the file to ignore for `UNITY_EDITOR`.  If you attempt to build for Android and the build fails, then you try to run in the editor after you get the following error:
```
Could not get current activity
UnityEngine.Debug:LogError(Object)
Mapbox.Unity.Telemetry.TelemetryAndroid:Initialize(String) (at Assets/Mapbox/Unity/Telemetry/TelemetryAndroid.cs:34)
Mapbox.Unity.MapboxAccess:ConfigureTelemetry() (at Assets/Mapbox/Unity/MapboxAccess.cs:191)
Mapbox.Unity.MapboxAccess:SetConfiguration(MapboxConfiguration, Boolean) (at Assets/Mapbox/Unity/MapboxAccess.cs:106)
Mapbox.Unity.MapboxAccess:LoadAccessToken() (at Assets/Mapbox/Unity/MapboxAccess.cs:158)
Mapbox.Unity.MapboxAccess:.ctor() (at Assets/Mapbox/Unity/MapboxAccess.cs:64)
Mapbox.Unity.MapboxAccess:get_Instance() (at Assets/Mapbox/Unity/MapboxAccess.cs:39)
Mapbox.Unity.Map.<SetupAccess>c__Iterator0:MoveNext() (at Assets/Mapbox/Unity/Map/AbstractMap.cs:421)
UnityEngine.MonoBehaviour:StartCoroutine(String)
Mapbox.Unity.Map.AbstractMap:Start() (at Assets/Mapbox/Unity/Map/AbstractMap.cs:412)

```
To be able to run in the editor again you need to restart Unity, this change fixes that.