### PR TITLE
Remove frame delay

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -481,9 +481,6 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 
 		protected IEnumerator ProcessLayer(VectorTileLayer layer, UnityTile tile, UnwrappedTileId tileId, Action<UnityTile, LayerVisualizerBase> callback = null)
 		{
-			//HACK to prevent request finishing on same frame which breaks modules started/finished events
-			yield return null;
-
 			if (tile == null)
 			{
 				yield break;


### PR DESCRIPTION
This PR removes the old one frame delay we had to ensure map state change event work properly.
After the map progress detection changes done a few months ago though, we shouldn't need this anymore. It creates confusion with that somewhat hidden one frame delay.
I tested it with any demo scene using loading screen. loading screen object registers to map state change event and I tested to see if there are any duplicates or out-of-order events. 

@atripathi-mb @jordy-isaac 