### PR TITLE
Tile events

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/3_POIPlacement/POIPlacement.unity
+++ b/sdkproject/Assets/Mapbox/Examples/3_POIPlacement/POIPlacement.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,7 +38,8 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465785, g: 0.49641252, b: 0.574817, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465934, g: 0.49642956, b: 0.5748249, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -54,11 +55,10 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 40
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -221,14 +221,14 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: b95c449128f3b44bca8b83258c669aa5, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: b95c449128f3b44bca8b83258c669aa5, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &150549877
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 150549879}
   - component: {fileID: 150549878}
@@ -242,7 +242,7 @@ GameObject:
 --- !u!108 &150549878
 Light:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 150549877}
   m_Enabled: 1
@@ -269,6 +269,7 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
@@ -278,7 +279,7 @@ Light:
 --- !u!4 &150549879
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 150549877}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
@@ -291,10 +292,10 @@ Transform:
 --- !u!1 &292492997
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1291234444091486, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1291234444091486, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 292492998}
   - component: {fileID: 292493000}
@@ -309,7 +310,7 @@ GameObject:
 --- !u!224 &292492998
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224771389989224222, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224771389989224222, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 292492997}
@@ -328,7 +329,7 @@ RectTransform:
 --- !u!114 &292492999
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114848192389514190, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114848192389514190, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 292492997}
@@ -356,17 +357,18 @@ MonoBehaviour:
 --- !u!222 &292493000
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222371227108701474, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222371227108701474, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 292492997}
+  m_CullTransparentMesh: 0
 --- !u!1 &331047608
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1130209808532952, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1130209808532952, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 331047609}
   m_Layer: 5
@@ -379,7 +381,7 @@ GameObject:
 --- !u!224 &331047609
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224885144614080300, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224885144614080300, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 331047608}
@@ -399,9 +401,9 @@ RectTransform:
 --- !u!1 &621795784
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 621795785}
   - component: {fileID: 621795786}
@@ -415,7 +417,7 @@ GameObject:
 --- !u!4 &621795785
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 621795784}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -428,13 +430,17 @@ Transform:
 --- !u!20 &621795786
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 621795784}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 3
   m_BackGroundColor: {r: 0.13235295, g: 0.13235295, b: 0.13235295, a: 1}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -464,10 +470,10 @@ Camera:
 --- !u!1 &650732808
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1599729465296294, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1599729465296294, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 650732809}
   m_Layer: 5
@@ -480,7 +486,7 @@ GameObject:
 --- !u!224 &650732809
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224748083790024428, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224748083790024428, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 650732808}
@@ -595,15 +601,15 @@ Prefab:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 3adcee2515f8c49f4a7afb3bacf2c56e, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 3adcee2515f8c49f4a7afb3bacf2c56e, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &790657048
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1768860123691022, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1768860123691022, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 790657049}
   - component: {fileID: 790657051}
@@ -618,7 +624,7 @@ GameObject:
 --- !u!224 &790657049
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224917229095272750, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224917229095272750, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 790657048}
@@ -637,7 +643,7 @@ RectTransform:
 --- !u!114 &790657050
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114517333868574894, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114517333868574894, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 790657048}
@@ -665,15 +671,16 @@ MonoBehaviour:
 --- !u!222 &790657051
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222359169490577362, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222359169490577362, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 790657048}
+  m_CullTransparentMesh: 0
 --- !u!21 &838017926
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: DefaultSideMaterial
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
@@ -928,14 +935,14 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 98be219873e6d4dffb5949746f515a33, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &967308905
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 967308907}
   - component: {fileID: 967308906}
@@ -949,7 +956,7 @@ GameObject:
 --- !u!114 &967308906
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 967308905}
   m_Enabled: 1
@@ -962,17 +969,17 @@ MonoBehaviour:
       latitudeLongitude: 37.784179, -122.401583
       zoom: 16
     extentOptions:
-      extentType: 0
+      extentType: 1
       defaultExtents:
         cameraBoundsOptions:
           camera: {fileID: 1681481105}
           visibleBuffer: 0
           disposeBuffer: 0
         rangeAroundCenterOptions:
-          west: 1
-          north: 1
-          east: 1
-          south: 1
+          west: 0
+          north: 0
+          east: 0
+          south: 0
         rangeAroundTransformOptions:
           targetTransform: {fileID: 0}
           visibleBuffer: 0
@@ -1140,7 +1147,7 @@ MonoBehaviour:
       locationPrefabList:
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Arts and Entertainment
           geometryType: 0
           layerName: poi_label
@@ -1220,7 +1227,7 @@ MonoBehaviour:
         density: 15
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Food
           geometryType: 0
           layerName: poi_label
@@ -1300,7 +1307,7 @@ MonoBehaviour:
         density: 15
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Nightlife
           geometryType: 0
           layerName: poi_label
@@ -1380,7 +1387,7 @@ MonoBehaviour:
         density: 15
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Outdoors and Recreation
           geometryType: 0
           layerName: poi_label
@@ -1460,7 +1467,7 @@ MonoBehaviour:
         density: 15
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Services
           geometryType: 0
           layerName: poi_label
@@ -1540,7 +1547,7 @@ MonoBehaviour:
         density: 10
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Shops
           geometryType: 0
           layerName: poi_label
@@ -1620,7 +1627,7 @@ MonoBehaviour:
         density: 15
       - coreOptions:
           sourceId: 
-          isActive: 1
+          isActive: 0
           sublayerName: Transportation
           geometryType: 0
           layerName: poi_label
@@ -1778,7 +1785,7 @@ MonoBehaviour:
 --- !u!4 &967308907
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 967308905}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -1791,10 +1798,10 @@ Transform:
 --- !u!1 &987810028
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1478380032039622, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1478380032039622, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 987810029}
   - component: {fileID: 987810031}
@@ -1809,7 +1816,7 @@ GameObject:
 --- !u!224 &987810029
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224022329360643548, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224022329360643548, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 987810028}
@@ -1828,7 +1835,7 @@ RectTransform:
 --- !u!114 &987810030
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114615401511486178, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114615401511486178, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 987810028}
@@ -1862,17 +1869,18 @@ MonoBehaviour:
 --- !u!222 &987810031
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222471317231544810, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222471317231544810, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 987810028}
+  m_CullTransparentMesh: 0
 --- !u!1 &1025723464
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1466557346746850, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1466557346746850, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1025723466}
   - component: {fileID: 1025723465}
@@ -1886,7 +1894,7 @@ GameObject:
 --- !u!114 &1025723465
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114023684558016336, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114023684558016336, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1025723464}
@@ -1935,7 +1943,7 @@ MonoBehaviour:
 --- !u!224 &1025723466
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224155718882878594, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224155718882878594, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1025723464}
@@ -1957,10 +1965,10 @@ RectTransform:
 --- !u!1 &1077699859
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1452734211165118, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1452734211165118, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1077699860}
   - component: {fileID: 1077699862}
@@ -1975,7 +1983,7 @@ GameObject:
 --- !u!224 &1077699860
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224120818998345342, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224120818998345342, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1077699859}
@@ -1994,7 +2002,7 @@ RectTransform:
 --- !u!114 &1077699861
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114608658907116364, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114608658907116364, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1077699859}
@@ -2028,17 +2036,18 @@ MonoBehaviour:
 --- !u!222 &1077699862
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222195337741236042, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222195337741236042, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1077699859}
+  m_CullTransparentMesh: 0
 --- !u!1 &1185540384
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1465653171882796, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1465653171882796, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1185540385}
   - component: {fileID: 1185540388}
@@ -2054,7 +2063,7 @@ GameObject:
 --- !u!224 &1185540385
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224031879083185220, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224031879083185220, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1185540384}
@@ -2075,7 +2084,7 @@ RectTransform:
 --- !u!114 &1185540386
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114225640444197696, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114225640444197696, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1185540384}
@@ -2103,14 +2112,15 @@ MonoBehaviour:
 --- !u!222 &1185540387
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222276008827229016, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222276008827229016, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1185540384}
+  m_CullTransparentMesh: 0
 --- !u!114 &1185540388
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114539028991012686, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114539028991012686, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1185540384}
@@ -2133,10 +2143,10 @@ MonoBehaviour:
 --- !u!1 &1301353179
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1884765832795660, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1884765832795660, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1301353180}
   - component: {fileID: 1301353182}
@@ -2151,7 +2161,7 @@ GameObject:
 --- !u!224 &1301353180
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224460312872028030, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224460312872028030, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1301353179}
@@ -2170,7 +2180,7 @@ RectTransform:
 --- !u!114 &1301353181
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114470729243328852, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114470729243328852, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1301353179}
@@ -2204,15 +2214,16 @@ MonoBehaviour:
 --- !u!222 &1301353182
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222758917679313182, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222758917679313182, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1301353179}
+  m_CullTransparentMesh: 0
 --- !u!21 &1325882990
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: DefaultTopMaterial
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
@@ -2285,10 +2296,10 @@ Material:
 --- !u!1 &1435841541
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1414859872329428, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1414859872329428, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1435841542}
   - component: {fileID: 1435841545}
@@ -2305,7 +2316,7 @@ GameObject:
 --- !u!224 &1435841542
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224048572454037920, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224048572454037920, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1435841541}
@@ -2326,7 +2337,7 @@ RectTransform:
 --- !u!114 &1435841543
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114711793206807384, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114711793206807384, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1435841541}
@@ -2401,7 +2412,7 @@ MonoBehaviour:
 --- !u!114 &1435841544
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114431620286575106, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114431620286575106, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1435841541}
@@ -2429,14 +2440,15 @@ MonoBehaviour:
 --- !u!222 &1435841545
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222386617050530544, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222386617050530544, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1435841541}
+  m_CullTransparentMesh: 0
 --- !u!114 &1435841546
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114850405259029928, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114850405259029928, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1435841541}
@@ -2449,7 +2461,7 @@ MonoBehaviour:
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: SimpleSideMaterial
   m_Shader: {fileID: 4800000, guid: 02ca05f28416c4bbab659e473fa74ec6, type: 3}
@@ -2548,9 +2560,9 @@ Material:
 --- !u!1 &1681481099
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1681481106}
   - component: {fileID: 1681481105}
@@ -2569,7 +2581,7 @@ GameObject:
 --- !u!114 &1681481100
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
@@ -2581,7 +2593,7 @@ MonoBehaviour:
 --- !u!114 &1681481101
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
@@ -2596,34 +2608,38 @@ MonoBehaviour:
 --- !u!81 &1681481102
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
 --- !u!124 &1681481103
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
 --- !u!92 &1681481104
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
 --- !u!20 &1681481105
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0.13235295, g: 0.13235295, b: 0.13235295, a: 1}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -2653,7 +2669,7 @@ Camera:
 --- !u!4 &1681481106
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1681481099}
   m_LocalRotation: {x: 0.2588191, y: 0, z: 0, w: 0.9659258}
@@ -2667,10 +2683,10 @@ Transform:
 --- !u!1 &1705615810
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1309470221448190, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1309470221448190, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1705615811}
   - component: {fileID: 1705615813}
@@ -2685,7 +2701,7 @@ GameObject:
 --- !u!224 &1705615811
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224333804213914554, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224333804213914554, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1705615810}
@@ -2704,7 +2720,7 @@ RectTransform:
 --- !u!114 &1705615812
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114620971063286122, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114620971063286122, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1705615810}
@@ -2738,17 +2754,18 @@ MonoBehaviour:
 --- !u!222 &1705615813
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222294672724154868, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222294672724154868, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1705615810}
+  m_CullTransparentMesh: 0
 --- !u!1 &1780367436
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1246307186655398, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1246307186655398, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1780367441}
   - component: {fileID: 1780367440}
@@ -2765,7 +2782,7 @@ GameObject:
 --- !u!114 &1780367437
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114632240689637620, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114632240689637620, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780367436}
@@ -2779,7 +2796,7 @@ MonoBehaviour:
 --- !u!114 &1780367438
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114398042337336202, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114398042337336202, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780367436}
@@ -2796,7 +2813,7 @@ MonoBehaviour:
 --- !u!114 &1780367439
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114329158974351212, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114329158974351212, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780367436}
@@ -2818,7 +2835,7 @@ MonoBehaviour:
 --- !u!223 &1780367440
 Canvas:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 223082131773786238, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 223082131773786238, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780367436}
@@ -2839,7 +2856,7 @@ Canvas:
 --- !u!224 &1780367441
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224709793726594912, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224709793726594912, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780367436}
@@ -2859,10 +2876,10 @@ RectTransform:
 --- !u!1 &1856430727
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1041193504261098, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1041193504261098, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1856430728}
   m_Layer: 5
@@ -2875,7 +2892,7 @@ GameObject:
 --- !u!224 &1856430728
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224178813210018432, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224178813210018432, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1856430727}
@@ -2896,10 +2913,10 @@ RectTransform:
 --- !u!1 &2086915428
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1748656016281148, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1748656016281148, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 2086915429}
   - component: {fileID: 2086915430}
@@ -2914,7 +2931,7 @@ GameObject:
 --- !u!224 &2086915429
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224722295744740158, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224722295744740158, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2086915428}
@@ -2933,14 +2950,15 @@ RectTransform:
 --- !u!222 &2086915430
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222410947139892146, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 222410947139892146, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2086915428}
+  m_CullTransparentMesh: 0
 --- !u!114 &2086915431
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114372218451069632, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 114372218451069632, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2086915428}
@@ -2969,7 +2987,7 @@ MonoBehaviour:
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: SimpleTopMaterial
   m_Shader: {fileID: 4800000, guid: 02ca05f28416c4bbab659e473fa74ec6, type: 3}
@@ -3068,10 +3086,10 @@ Material:
 --- !u!1 &2141323937
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1401021118005222, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 1401021118005222, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 2141323938}
   m_Layer: 5
@@ -3084,7 +3102,7 @@ GameObject:
 --- !u!224 &2141323938
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224538534500426518, guid: 00f5bf1ff996842fc82384f8f686fda6,
+  m_CorrespondingSourceObject: {fileID: 224538534500426518, guid: 00f5bf1ff996842fc82384f8f686fda6,
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2141323937}

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
@@ -28,14 +28,6 @@ namespace Mapbox.Examples
 			_map.OnEditorPreviewEnabled += OnEditorPreviewEnabled;
 			_map.OnEditorPreviewDisabled += OnEditorPreviewDisabled;
 
-			_map.OnTilesStarting += (s) => { Debug.Log("Starting " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
-			_map.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
-			_map.OnTilesDisposing += (s) => { Debug.Log("Disposing " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
-
-			_map.MapVisualizer.OnTileHeightProcessingFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
-			_map.MapVisualizer.OnTileImageProcessingFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
-			_map.MapVisualizer.OnTileVectorProcessingFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
-
 		}
 
 		void _map_OnInitialized()

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
@@ -1,4 +1,6 @@
 
+using System.Linq;
+
 namespace Mapbox.Examples
 {
 	using UnityEngine;
@@ -27,18 +29,19 @@ namespace Mapbox.Examples
 			_map.OnEditorPreviewEnabled += OnEditorPreviewEnabled;
 			_map.OnEditorPreviewDisabled += OnEditorPreviewDisabled;
 
-			_map.OnTileRequestRecieved += (s) => { Debug.Log("Starting " + s); };
-			_map.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
-
-			_map.Terrain.OnTileFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
-			_map.ImageLayer.OnTileFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
-			_map.VectorData.OnTileFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
-
 
 		}
 
 		void _map_OnInitialized()
 		{
+			_map.OnTilesStarting += (s) => { Debug.Log("Starting " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
+			_map.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
+			_map.OnTilesDisposing += (s) => { Debug.Log("Disposing " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
+
+			_map.MapVisualizer.OnTileHeightProcessingFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
+			_map.MapVisualizer.OnTileImageProcessingFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
+			_map.MapVisualizer.OnTileVectorProcessingFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
+
 			var visualizer = _map.MapVisualizer;
 			_text.text = "LOADING";
 			visualizer.OnMapVisualizerStateChanged += (s) =>

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
@@ -26,6 +26,15 @@ namespace Mapbox.Examples
 
 			_map.OnEditorPreviewEnabled += OnEditorPreviewEnabled;
 			_map.OnEditorPreviewDisabled += OnEditorPreviewDisabled;
+
+			_map.OnTileRequestRecieved += (s) => { Debug.Log("Starting " + s); };
+			_map.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
+
+			_map.Terrain.OnTileFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
+			_map.ImageLayer.OnTileFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
+			_map.VectorData.OnTileFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
+
+
 		}
 
 		void _map_OnInitialized()

--- a/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
+++ b/sdkproject/Assets/Mapbox/Examples/Scripts/LoadingPanelController.cs
@@ -22,18 +22,12 @@ namespace Mapbox.Examples
 		AbstractMap _map;
 		void Awake()
 		{
-
 			_map = FindObjectOfType<AbstractMap>();
 			_map.OnInitialized += _map_OnInitialized;
 
 			_map.OnEditorPreviewEnabled += OnEditorPreviewEnabled;
 			_map.OnEditorPreviewDisabled += OnEditorPreviewDisabled;
 
-
-		}
-
-		void _map_OnInitialized()
-		{
 			_map.OnTilesStarting += (s) => { Debug.Log("Starting " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
 			_map.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
 			_map.OnTilesDisposing += (s) => { Debug.Log("Disposing " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
@@ -41,6 +35,11 @@ namespace Mapbox.Examples
 			_map.MapVisualizer.OnTileHeightProcessingFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
 			_map.MapVisualizer.OnTileImageProcessingFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
 			_map.MapVisualizer.OnTileVectorProcessingFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
+
+		}
+
+		void _map_OnInitialized()
+		{
 
 			var visualizer = _map.MapVisualizer;
 			_text.text = "LOADING";

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -70,6 +70,10 @@ namespace Mapbox.Unity.Map
 		{
 			get
 			{
+				if(_mapVisualizer == null)
+				{
+					_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+				}
 				return _mapVisualizer;
 			}
 			set
@@ -501,7 +505,11 @@ namespace Mapbox.Unity.Map
 			// Destroy any ghost game objects.
 			DestroyChildObjects();
 			// Setup a visualizer to get a "Starter" map.
-			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+
+			if(_mapVisualizer == null)
+			{
+				_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+			}
 			_mapVisualizer.OnTileFinished += (s) =>
 			{
 				OnTileFinished(s);

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -1229,10 +1229,25 @@ namespace Mapbox.Unity.Map
 		public event Action OnUpdated = delegate { };
 		public event Action OnMapRedrawn = delegate { };
 
+		/// <summary>
+		/// Event delegate, gets called when map preview is enabled
+		/// </summary>
 		public event Action OnEditorPreviewEnabled = delegate { };
+		/// <summary>
+		/// Event delegate, gets called when map preview is disabled
+		/// </summary>
 		public event Action OnEditorPreviewDisabled = delegate { };
+		/// <summary>
+		/// Event delegate, gets called when a tile is completed.
+		/// </summary>
 		public event Action<UnityTile> OnTileFinished = delegate { };
+		/// <summary>
+		/// Event delegate, gets called when new tiles coordinates are registered.
+		/// </summary>
 		public event Action<List<UnwrappedTileId>> OnTilesStarting = delegate { };
+		/// <summary>
+		/// Event delegate, gets called before a tile is getting recycled.
+		/// </summary>
 		public event Action<List<UnwrappedTileId>> OnTilesDisposing = delegate { };
 		#endregion
 	}

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -500,6 +500,7 @@ namespace Mapbox.Unity.Map
 			DestroyChildObjects();
 			// Setup a visualizer to get a "Starter" map.
 			_mapVisualizer = ScriptableObject.CreateInstance<MapVisualizer>();
+			_mapVisualizer.OnTileFinished += OnTileFinished;
 		}
 
 		public void DestroyChildObjects()
@@ -639,6 +640,7 @@ namespace Mapbox.Unity.Map
 
 		protected virtual void TileProvider_OnTileAdded(UnwrappedTileId tileId)
 		{
+			OnTileRequestRecieved(tileId);
 			var tile = _mapVisualizer.LoadTile(tileId);
 			if (Options.placementOptions.snapMapToZero && !_worldHeightFixed)
 			{
@@ -1203,6 +1205,8 @@ namespace Mapbox.Unity.Map
 
 		public event Action OnEditorPreviewEnabled = delegate { };
 		public event Action OnEditorPreviewDisabled = delegate { };
+		public event Action<UnityTile> OnTileFinished = delegate { };
+		public event Action<UnwrappedTileId> OnTileRequestRecieved = delegate { };
 		#endregion
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -186,6 +186,7 @@ namespace Mapbox.Unity.Map
 
 			if (rasterDone && terrainDone && vectorDone)
 			{
+				Debug.Log("Tile Done");
 				tile.TileState = MeshGeneration.Enums.TilePropertyState.Loaded;
 				OnTileFinished(tile);
 
@@ -319,21 +320,6 @@ namespace Mapbox.Unity.Map
 			State = ModuleState.Initialized;
 		}
 
-		#region Events
-		/// <summary>
-		/// The  <c>OnTileError</c> event triggers when there's a <c>Tile</c> error.
-		/// Returns a <see cref="T:Mapbox.Map.TileErrorEventArgs"/> instance as a parameter, for the tile on which error occurred.
-		/// </summary>
-		public event EventHandler<TileErrorEventArgs> OnTileError;
-		private void Factory_OnTileError(object sender, TileErrorEventArgs e)
-		{
-			EventHandler<TileErrorEventArgs> handler = OnTileError;
-			if (handler != null)
-			{
-				handler(this, e);
-			}
-		}
-
 		public void ReregisterAllTiles()
 		{
 			foreach (var activeTile in _activeTiles)
@@ -404,14 +390,36 @@ namespace Mapbox.Unity.Map
 				factory.UpdateTileProperty(tileBundle.Value, updateArgs);
 			}
 		}
-		#endregion
 
-//		public event Action<UnityTile> OnTileHeightProcessingStarting;
-//		public event Action<UnityTile> OnTileImageProcessingStarting;
-//		public event Action<UnityTile> OnTileVectorProcessingStarting;
 
+		#region Events
+		/// <summary>
+		/// The  <c>OnTileError</c> event triggers when there's a <c>Tile</c> error.
+		/// Returns a <see cref="T:Mapbox.Map.TileErrorEventArgs"/> instance as a parameter, for the tile on which error occurred.
+		/// </summary>
+		public event EventHandler<TileErrorEventArgs> OnTileError;
+		private void Factory_OnTileError(object sender, TileErrorEventArgs e)
+		{
+			EventHandler<TileErrorEventArgs> handler = OnTileError;
+			if (handler != null)
+			{
+				handler(this, e);
+			}
+		}
+
+		/// <summary>
+		/// Event delegate, gets called when terrain factory finishes processing a tile.
+		/// </summary>
 		public event Action<UnityTile> OnTileHeightProcessingFinished = delegate {};
+		/// <summary>
+		/// Event delegate, gets called when image factory finishes processing a tile.
+		/// </summary>
 		public event Action<UnityTile> OnTileImageProcessingFinished = delegate {};
+		/// <summary>
+		/// Event delegate, gets called when vector factory finishes processing a tile.
+		/// </summary>
 		public event Action<UnityTile> OnTileVectorProcessingFinished = delegate {};
+
+		#endregion
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -56,6 +56,7 @@ namespace Mapbox.Unity.Map
 		public Dictionary<UnwrappedTileId, int> _tileProgress;
 
 		public event Action<ModuleState> OnMapVisualizerStateChanged = delegate { };
+		public event Action<UnityTile> OnTileFinished = delegate { };
 
 		/// <summary>
 		/// Gets the unity tile from unwrapped tile identifier.
@@ -158,6 +159,7 @@ namespace Mapbox.Unity.Map
 			if (rasterDone && terrainDone && vectorDone)
 			{
 				tile.TileState = MeshGeneration.Enums.TilePropertyState.Loaded;
+				OnTileFinished(tile);
 
 				// Check if all tiles in extent are active tiles
 				if (_map.CurrentExtent.Count == _activeTiles.Count)
@@ -182,6 +184,8 @@ namespace Mapbox.Unity.Map
 				{
 					State = ModuleState.Working;
 				}
+
+
 			}
 		}
 		#endregion

--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMapVisualizer.cs
@@ -140,6 +140,34 @@ namespace Mapbox.Unity.Map
 		#region Factory event callbacks
 		//factory event callback, not relaying this up for now
 
+
+		private void TileHeightStateChanged(UnityTile tile)
+		{
+			if (tile.HeightDataState == TilePropertyState.Loaded)
+			{
+				OnTileHeightProcessingFinished(tile);
+			}
+			TileStateChanged(tile);
+		}
+
+		private void TileRasterStateChanged(UnityTile tile)
+		{
+			if (tile.RasterDataState == TilePropertyState.Loaded)
+			{
+				OnTileImageProcessingFinished(tile);
+			}
+			TileStateChanged(tile);
+		}
+
+		private void TileVectorStateChanged(UnityTile tile)
+		{
+			if (tile.VectorDataState == TilePropertyState.Loaded)
+			{
+				OnTileVectorProcessingFinished(tile);
+			}
+			TileStateChanged(tile);
+		}
+
 		public virtual void TileStateChanged(UnityTile tile)
 		{
 			bool rasterDone = (tile.RasterDataState == TilePropertyState.None ||
@@ -217,9 +245,9 @@ namespace Mapbox.Unity.Map
 #if UNITY_EDITOR
 			unityTile.gameObject.name = unityTile.CanonicalTileId.ToString();
 #endif
-			unityTile.OnHeightDataChanged += TileStateChanged;
-			unityTile.OnRasterDataChanged += TileStateChanged;
-			unityTile.OnVectorDataChanged += TileStateChanged;
+			unityTile.OnHeightDataChanged += TileHeightStateChanged;
+			unityTile.OnRasterDataChanged += TileRasterStateChanged;
+			unityTile.OnVectorDataChanged += TileVectorStateChanged;
 
 			unityTile.TileState = MeshGeneration.Enums.TilePropertyState.Loading;
 			ActiveTiles.Add(tileId, unityTile);
@@ -378,6 +406,12 @@ namespace Mapbox.Unity.Map
 		}
 		#endregion
 
+//		public event Action<UnityTile> OnTileHeightProcessingStarting;
+//		public event Action<UnityTile> OnTileImageProcessingStarting;
+//		public event Action<UnityTile> OnTileVectorProcessingStarting;
 
+		public event Action<UnityTile> OnTileHeightProcessingFinished = delegate {};
+		public event Action<UnityTile> OnTileImageProcessingFinished = delegate {};
+		public event Action<UnityTile> OnTileVectorProcessingFinished = delegate {};
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/AbstractTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/AbstractTileFactory.cs
@@ -44,8 +44,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		protected HashSet<UnityTile> _tilesWaitingResponse;
 		protected HashSet<UnityTile> _tilesWaitingProcessing;
 
-		public Action<UnityTile> OnTileFinished = delegate {};
-
 		public virtual void SetOptions(LayerProperties options)
 		{
 			_options = options;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/AbstractTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/AbstractTileFactory.cs
@@ -35,16 +35,16 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		protected IFileSource _fileSource;
 
 		protected LayerProperties _options;
+
 		public LayerProperties Options
 		{
-			get
-			{
-				return _options;
-			}
+			get { return _options; }
 		}
 
 		protected HashSet<UnityTile> _tilesWaitingResponse;
 		protected HashSet<UnityTile> _tilesWaitingProcessing;
+
+		public Action<UnityTile> OnTileFinished = delegate {};
 
 		public virtual void SetOptions(LayerProperties options)
 		{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
@@ -64,9 +64,11 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		{
 			if (tile != null)
 			{
+				_tilesWaitingResponse.Remove(tile);
+				OnTileFinished(tile);
+
 				if (tile.RasterDataState != TilePropertyState.Unregistered)
 				{
-					_tilesWaitingResponse.Remove(tile);
 					tile.SetRasterData(rasterTile.Data, _properties.rasterOptions.useMipMap, _properties.rasterOptions.useCompression);
 				}
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
@@ -65,7 +65,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			if (tile != null)
 			{
 				_tilesWaitingResponse.Remove(tile);
-				OnTileFinished(tile);
 
 				if (tile.RasterDataState != TilePropertyState.Unregistered)
 				{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -64,6 +64,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				tile.SetHeightData(null);
 				tile.MeshFilter.sharedMesh.Clear();
 				tile.ElevationType = TileTerrainType.None;
+				tile.HeightDataState = TilePropertyState.None;
 				return;
 			}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -122,11 +122,15 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			if (tile != null)
 			{
 				_tilesWaitingResponse.Remove(tile);
+				OnTileFinished(tile);
+
 				if (tile.HeightDataState != TilePropertyState.Unregistered)
 				{
 					tile.SetHeightData(pngRasterTile.Data, _elevationOptions.requiredOptions.exaggerationFactor, _elevationOptions.modificationOptions.useRelativeHeight, _elevationOptions.colliderOptions.addCollider);
 					Strategy.RegisterTile(tile);
 				}
+
+
 			}
 		}
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -122,7 +122,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			if (tile != null)
 			{
 				_tilesWaitingResponse.Remove(tile);
-				OnTileFinished(tile);
 
 				if (tile.HeightDataState != TilePropertyState.Unregistered)
 				{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -460,7 +460,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				}
 				if (_layerProgress[tile].Count == 0)
 				{
-					OnTileFinished(tile);
 					_layerProgress.Remove(tile);
 					_tilesWaitingProcessing.Remove(tile);
 					tile.VectorDataState = TilePropertyState.Loaded;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -374,6 +374,9 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		#region Private Methods
 		private void CreateMeshes(UnityTile tile)
 		{
+			var nameList = new List<string>();
+			var builderList = new List<LayerVisualizerBase>();
+
 			foreach (var layerName in tile.VectorData.Data.LayerNames())
 			{
 				if (_layerBuilder.ContainsKey(layerName))
@@ -381,16 +384,18 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 					//two loops; first one to add it to waiting/tracking list, second to start it
 					foreach (var builder in _layerBuilder[layerName])
 					{
+						nameList.Add(layerName);
+						builderList.Add(builder);
 						TrackFeatureWithBuilder(tile, layerName, builder);
-					}
-
-					foreach (var builder in _layerBuilder[layerName])
-					{
-						CreateFeatureWithBuilder(tile, layerName, builder);
 					}
 				}
 			}
+			for (int i = 0; i < nameList.Count; i++)
+			{
+				CreateFeatureWithBuilder(tile, nameList[i], builderList[i]);
+			}
 
+			builderList.Clear();
 			//emptylayer for visualizers that don't depend on outside data sources
 			string emptyLayer = "";
 			if (_layerBuilder.ContainsKey(emptyLayer))
@@ -398,13 +403,13 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				//two loops; first one to add it to waiting/tracking list, second to start it
 				foreach (var builder in _layerBuilder[emptyLayer])
 				{
+					builderList.Add(builder);
 					TrackFeatureWithBuilder(tile, emptyLayer, builder);
 				}
-
-				foreach (var builder in _layerBuilder[emptyLayer])
-				{
-					CreateFeatureWithBuilder(tile, emptyLayer, builder);
-				}
+			}
+			for (int i = 0; i < builderList.Count; i++)
+			{
+				CreateFeatureWithBuilder(tile, emptyLayer, builderList[i]);
 			}
 
 			if (!_layerProgress.ContainsKey(tile))

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
@@ -33,8 +33,6 @@ namespace Mapbox.Unity.Map
 		void Initialize(LayerProperties properties);
 		void Update(LayerProperties properties);
 		void Remove();
-
-		event Action<UnityTile> OnTileFinished;
 	}
 
 	public interface IVectorDataLayer : ILayer

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Mapbox.Unity.MeshGeneration.Data;
 using Mapbox.Unity.SourceLayers;
 
 namespace Mapbox.Unity.Map
@@ -33,6 +34,7 @@ namespace Mapbox.Unity.Map
 		void Update(LayerProperties properties);
 		void Remove();
 
+		event Action<UnityTile> OnTileFinished;
 	}
 
 	public interface IVectorDataLayer : ILayer

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
@@ -111,7 +111,6 @@ namespace Mapbox.Unity.Map
 			}
 			_imageFactory = ScriptableObject.CreateInstance<MapImageFactory>();
 			_imageFactory.SetOptions(_layerProperty);
-			_imageFactory.OnTileFinished += OnTileFinished;
 			_layerProperty.PropertyHasChanged += RedrawLayer;
 			_layerProperty.rasterOptions.PropertyHasChanged += (property, e) =>
 			{
@@ -233,7 +232,5 @@ namespace Mapbox.Unity.Map
 			}
 		}
 		#endregion
-
-		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ImageryLayer.cs
@@ -1,4 +1,6 @@
-﻿namespace Mapbox.Unity.Map
+﻿using Mapbox.Unity.MeshGeneration.Data;
+
+namespace Mapbox.Unity.Map
 {
 	using System;
 	using UnityEngine;
@@ -109,6 +111,7 @@
 			}
 			_imageFactory = ScriptableObject.CreateInstance<MapImageFactory>();
 			_imageFactory.SetOptions(_layerProperty);
+			_imageFactory.OnTileFinished += OnTileFinished;
 			_layerProperty.PropertyHasChanged += RedrawLayer;
 			_layerProperty.rasterOptions.PropertyHasChanged += (property, e) =>
 			{
@@ -230,5 +233,7 @@
 			}
 		}
 		#endregion
+
+		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -1,4 +1,6 @@
-﻿namespace Mapbox.Unity.Map
+﻿using Mapbox.Unity.MeshGeneration.Data;
+
+namespace Mapbox.Unity.Map
 {
 	using System;
 	using UnityEngine;
@@ -124,6 +126,7 @@
 		public void Initialize()
 		{
 			_elevationFactory = ScriptableObject.CreateInstance<TerrainFactoryBase>();
+			_elevationFactory.OnTileFinished += OnTileFinished;
 			SetFactoryOptions();
 
 			_layerProperty.colliderOptions.PropertyHasChanged += (property, e) =>
@@ -194,6 +197,8 @@
 			};
 		}
 
+
+
 		public void Update(LayerProperties properties)
 		{
 			Initialize(properties);
@@ -204,7 +209,7 @@
 		/// <summary>
 		/// Sets the data source for Terrain Layer.
 		/// Defaults to MapboxTerrain.
-		/// Use <paramref name="terrainSource"/> = None, to disable the Terrain Layer. 
+		/// Use <paramref name="terrainSource"/> = None, to disable the Terrain Layer.
 		/// </summary>
 		/// <param name="terrainSource">Terrain source.</param>
 		public virtual void SetLayerSource(ElevationSourceType terrainSource = ElevationSourceType.MapboxTerrain)
@@ -222,8 +227,8 @@
 		}
 
 		/// <summary>
-		/// Sets the data source to a custom source for Terrain Layer. 
-		/// </summary> 
+		/// Sets the data source to a custom source for Terrain Layer.
+		/// </summary>
 		/// <param name="terrainSource">Terrain source.</param>
 		public virtual void SetLayerSource(string terrainSource)
 		{
@@ -364,5 +369,7 @@
 
 
 		#endregion
+
+		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/TerrainLayer.cs
@@ -126,7 +126,6 @@ namespace Mapbox.Unity.Map
 		public void Initialize()
 		{
 			_elevationFactory = ScriptableObject.CreateInstance<TerrainFactoryBase>();
-			_elevationFactory.OnTileFinished += OnTileFinished;
 			SetFactoryOptions();
 
 			_layerProperty.colliderOptions.PropertyHasChanged += (property, e) =>
@@ -369,7 +368,5 @@ namespace Mapbox.Unity.Map
 
 
 		#endregion
-
-		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -3,6 +3,7 @@ using Mapbox.Utils;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
+using Mapbox.Unity.MeshGeneration.Data;
 using Mapbox.Unity.MeshGeneration.Factories;
 using Mapbox.Unity.Utilities;
 
@@ -68,6 +69,7 @@ namespace Mapbox.Unity.Map
 		public void Initialize()
 		{
 			_vectorTileFactory = ScriptableObject.CreateInstance<VectorTileFactory>();
+			_vectorTileFactory.OnTileFinished += OnTileFinished;
 			UpdateFactorySettings();
 
 			_layerProperty.PropertyHasChanged += RedrawVectorLayer;
@@ -237,7 +239,7 @@ namespace Mapbox.Unity.Map
 		/// of them each frame.
 		/// </summary>
 		/// <param name="entityPerCoroutine">Numbers of features to process each frame.</param>
-		/// 
+		///
 		public virtual void EnableVectorFeatureProcessingWithCoroutines(int entityPerCoroutine = 20)
 		{
 			if (_layerProperty.performanceOptions.isEnabled != true ||
@@ -655,5 +657,7 @@ namespace Mapbox.Unity.Map
 			}
 		}
 		#endregion
+
+		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -69,7 +69,6 @@ namespace Mapbox.Unity.Map
 		public void Initialize()
 		{
 			_vectorTileFactory = ScriptableObject.CreateInstance<VectorTileFactory>();
-			_vectorTileFactory.OnTileFinished += OnTileFinished;
 			UpdateFactorySettings();
 
 			_layerProperty.PropertyHasChanged += RedrawVectorLayer;
@@ -658,6 +657,5 @@ namespace Mapbox.Unity.Map
 		}
 		#endregion
 
-		public event Action<UnityTile> OnTileFinished;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Unity/Tests/ApiTest.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Tests/ApiTest.cs
@@ -31,6 +31,15 @@ public class ApiTest : MonoBehaviour
 	void Start()
 	{
 		_abstractMap = FindObjectOfType<AbstractMap>();
+
+		_abstractMap.OnTilesStarting += (s) => { Debug.Log("Starting " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
+		_abstractMap.OnTileFinished += (s) => { Debug.Log("Finished " + s.CanonicalTileId); };
+		_abstractMap.OnTilesDisposing += (s) => { Debug.Log("Disposing " + string.Join(",", s.Select(x => x.ToString()).ToArray())); };
+
+		_abstractMap.MapVisualizer.OnTileHeightProcessingFinished += (s) => { Debug.Log("Terrain finished " + s.CanonicalTileId); };
+		_abstractMap.MapVisualizer.OnTileImageProcessingFinished += (s) => { Debug.Log("Image finished " + s.CanonicalTileId); };
+		_abstractMap.MapVisualizer.OnTileVectorProcessingFinished += (s) => { Debug.Log("Vector finished " + s.CanonicalTileId); };
+
 	}
 
 	[ContextMenu("ChangeExtentType")]


### PR DESCRIPTION
POC branch for tile event introduces bunch of new events; tile starting, finished, disposing, factory (terrain, image,vector separately) finished.

I feel tile starting, finished and disposing are fine at the moment. Just not happy with factory finished events being under map visualizer. Actually them being under map visualizer is fine, but you'll get null ref error on map visualizer if you try to get it too early (awake?) and I'm not a fan of that possible null ref. Maybe we can just create map visualizer on getter?

@atripathi-mb 