### PR TITLE
Terrain factory data state fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -64,6 +64,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				tile.SetHeightData(null);
 				tile.MeshFilter.sharedMesh.Clear();
 				tile.ElevationType = TileTerrainType.None;
+				tile.HeightDataState = TilePropertyState.None;
 				return;
 			}
 


### PR DESCRIPTION
fixes a bug where terrain factory doesn't set height data state when disabled and blocking map finish event because of it.

@atripathi-mb 