### PR TITLE
Data fetcher tile dependency fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
@@ -32,9 +32,9 @@ public class ImageDataFetcher : DataFetcher
 			imageDataParameters.tile.AddTile(rasterTile);
 		}
 
-		rasterTile.Initialize(_fileSource, imageDataParameters.tile.CanonicalTileId, imageDataParameters.mapid, () =>
+		rasterTile.Initialize(_fileSource, imageDataParameters.canonicalTileId, imageDataParameters.mapid, () =>
 		{
-			if (imageDataParameters.tile.CanonicalTileId != rasterTile.Id)
+			if (imageDataParameters.tile != null && imageDataParameters.tile.CanonicalTileId != rasterTile.Id)
 			{
 				//this means tile object is recycled and reused. Returned data doesn't belong to this tile but probably the previous one. So we're trashing it.
 				return;
@@ -42,7 +42,7 @@ public class ImageDataFetcher : DataFetcher
 
 			if (rasterTile.HasError)
 			{
-				FetchingError(imageDataParameters.tile, rasterTile, new TileErrorEventArgs(imageDataParameters.tile.CanonicalTileId, rasterTile.GetType(), imageDataParameters.tile, rasterTile.Exceptions));
+				FetchingError(imageDataParameters.tile, rasterTile, new TileErrorEventArgs(imageDataParameters.canonicalTileId, rasterTile.GetType(), imageDataParameters.tile, rasterTile.Exceptions));
 			}
 			else
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
@@ -53,12 +53,12 @@ public class TerrainDataFetcher : DataFetcher
 		var terrainDataParameters = parameters as TerrainDataFetcherParameters;
 		if(terrainDataParameters == null)
 		{
-			return;	
+			return;
 		}
 		var pngRasterTile = new RawPngRasterTile();
 		pngRasterTile.Initialize(_fileSource, terrainDataParameters.canonicalTileId, terrainDataParameters.mapid, () =>
 		{
-			if (terrainDataParameters.tile.CanonicalTileId != pngRasterTile.Id)
+			if (terrainDataParameters.tile != null && terrainDataParameters.tile.CanonicalTileId != pngRasterTile.Id)
 			{
 				//this means tile object is recycled and reused. Returned data doesn't belong to this tile but probably the previous one. So we're trashing it.
 				return;

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
@@ -56,6 +56,10 @@ public class TerrainDataFetcher : DataFetcher
 			return;
 		}
 		var pngRasterTile = new RawPngRasterTile();
+		if (terrainDataParameters.tile != null)
+		{
+			terrainDataParameters.tile.AddTile(pngRasterTile);
+		}
 		pngRasterTile.Initialize(_fileSource, terrainDataParameters.canonicalTileId, terrainDataParameters.mapid, () =>
 		{
 			if (terrainDataParameters.tile != null && terrainDataParameters.tile.CanonicalTileId != pngRasterTile.Id)

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
@@ -11,27 +11,30 @@ public class VectorDataFetcher : DataFetcher
 	//tile here should be totally optional and used only not to have keep a dictionary in terrain factory base
 	public override void FetchData(DataFetcherParameters parameters)
 	{
-		var vectorDaraParameters = parameters as VectorDataFetcherParameters;
-		if(vectorDaraParameters == null)
+		var vectorDataParameters = parameters as VectorDataFetcherParameters;
+		if(vectorDataParameters == null)
 		{
 			return;
 		}
-		var vectorTile = (vectorDaraParameters.useOptimizedStyle) ? new VectorTile(vectorDaraParameters.style.Id, vectorDaraParameters.style.Modified) : new VectorTile();
-		vectorDaraParameters.tile.AddTile(vectorTile);
-		vectorTile.Initialize(_fileSource, vectorDaraParameters.tile.CanonicalTileId, vectorDaraParameters.mapid, () =>
+		var vectorTile = (vectorDataParameters.useOptimizedStyle) ? new VectorTile(vectorDataParameters.style.Id, vectorDataParameters.style.Modified) : new VectorTile();
+		if (vectorDataParameters.tile != null)
 		{
-			if (vectorDaraParameters.tile.CanonicalTileId != vectorTile.Id)
+			vectorDataParameters.tile.AddTile(vectorTile);
+		}
+		vectorTile.Initialize(_fileSource, vectorDataParameters.canonicalTileId, vectorDataParameters.mapid, () =>
+		{
+			if (vectorDataParameters.tile != null && vectorDataParameters.tile.CanonicalTileId != vectorTile.Id)
 			{
 				//this means tile object is recycled and reused. Returned data doesn't belong to this tile but probably the previous one. So we're trashing it.
 				return;
 			}
 			if (vectorTile.HasError)
 			{
-				FetchingError(vectorDaraParameters.tile, vectorTile, new TileErrorEventArgs(vectorDaraParameters.tile.CanonicalTileId, vectorTile.GetType(), vectorDaraParameters.tile, vectorTile.Exceptions));
+				FetchingError(vectorDataParameters.tile, vectorTile, new TileErrorEventArgs(vectorDataParameters.canonicalTileId, vectorTile.GetType(), vectorDataParameters.tile, vectorTile.Exceptions));
 			}
 			else
 			{
-				DataRecieved(vectorDaraParameters.tile, vectorTile);
+				DataRecieved(vectorDataParameters.tile, vectorTile);
 			}
 		});
 	}


### PR DESCRIPTION
change data fetcher classes to handle null unity tile parameter and make it possible for them to work without one
Closes #1382 

@atripathi-mb @jordy-isaac 