### PR TITLE
world scale strategy fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/Strategies/MapScalingAtWorldScaleStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/Strategies/MapScalingAtWorldScaleStrategy.cs
@@ -8,7 +8,7 @@ namespace Mapbox.Unity.Map.Strategies
 		public void SetUpScaling(AbstractMap map)
 		{
 			var scaleFactor = Mathf.Pow(2, (map.AbsoluteZoom - map.InitialZoom));
-			map.SetWorldRelativeScale(scaleFactor * Mathf.Cos(Mathf.Deg2Rad * (float)map.CenterLatitudeLongitude.x));
+			map.SetWorldRelativeScale(scaleFactor);
 		}
 	}
 }


### PR DESCRIPTION
change world scale strategy to not include latitude compensation as it's unnecessary in this mode.

latitude compensation is necessary for fixed size tiles where we forces tiles to a fixed value. World scale ar isn't doing any scaling so should be able to use raw height data without any post-scaling.

Closes #1378

@atripathi-mb @jordy-isaac 