### PR TITLE
fix astronaut demo scene shader for mobile platforms

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/2_AstronautGame/AstronautGame/Building/CharacterBuildingShader.shader
+++ b/sdkproject/Assets/Mapbox/Examples/2_AstronautGame/AstronautGame/Building/CharacterBuildingShader.shader
@@ -181,11 +181,7 @@ Shader "CharacterBuildingShader"
 				TRANSFER_SHADOW_CASTER_NORMALOFFSET( o )
 				return o;
 			}
-			fixed4 frag( v2f IN
-			#if !defined( CAN_SKIP_VPOS )
-			, UNITY_VPOS_TYPE vpos : VPOS
-			#endif
-			) : SV_Target
+			fixed4 frag( v2f IN	) : SV_Target
 			{
 				UNITY_SETUP_INSTANCE_ID( IN );
 				Input surfIN;


### PR DESCRIPTION
fix astronaut scene building shader for mobile devices.

error was; 
`duplicate system value semantic definition: input semantic 'SV_POSITION' and input semantic 'VPOS'`

I removed VPOS definition from shader, which was created using amplify shader editor. tested for android build (just created build package, couldn't run it) and windows editor/build.

@atripathi-mb @jordy-isaac 