### PR TITLE
change MapId to TilesetId in all files

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRasterTile.cs
@@ -14,9 +14,9 @@ namespace Mapbox.Map
 	/// </summary>
 	public class ClassicRasterTile : RasterTile
 	{
-		internal override TileResource MakeTileResource(string mapId)
+		internal override TileResource MakeTileResource(string tilesetId)
 		{
-			return TileResource.MakeClassicRaster(Id, mapId);
+			return TileResource.MakeClassicRaster(Id, tilesetId);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRetinaRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/ClassicRetinaRasterTile.cs
@@ -14,9 +14,9 @@ namespace Mapbox.Map
 	/// </summary>
     public class ClassicRetinaRasterTile : ClassicRasterTile
 	{
-		internal override TileResource MakeTileResource(string mapId)
+		internal override TileResource MakeTileResource(string tilesetId)
 		{
-			return TileResource.MakeClassicRetinaRaster(Id, mapId);
+			return TileResource.MakeClassicRetinaRaster(Id, tilesetId);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Map.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Map.cs
@@ -25,11 +25,11 @@ namespace Mapbox.Map
 	/// var map = new Map&lt;RasterTile&gt;(MapboxAccess.Instance);
 	/// map.Zoom = 2
 	/// map.Vector2dBounds = Vector2dBounds.World();
-	/// map.MapId = "mapbox://styles/mapbox/streets-v10
-	/// 
+	/// map.TilesetId = "mapbox://styles/mapbox/streets-v10
+	///
 	/// // Register for tile updates.
 	/// map.Subscribe(this);
-	/// 
+	///
 	/// // Trigger the request.
 	/// map.Update();
 	/// </code>
@@ -44,7 +44,7 @@ namespace Mapbox.Map
 		private readonly IFileSource fs;
 		private Vector2dBounds latLngBounds;
 		private int zoom;
-		private string mapId;
+		private string tilesetId;
 
 		private HashSet<T> tiles = new HashSet<T>();
 		private List<Mapbox.Utils.IObserver<T>> observers = new List<Mapbox.Utils.IObserver<T>>();
@@ -61,30 +61,30 @@ namespace Mapbox.Map
 		}
 
 		/// <summary>
-		///     Gets or sets the tileset map ID. If not set, it will use the default
-		///     map ID for the tile type. I.e. "mapbox.satellite" for raster tiles
+		///     Gets or sets the tileset ID. If not set, it will use the default
+		///     tileset ID for the tile type. I.e. "mapbox.satellite" for raster tiles
 		///     and "mapbox.mapbox-streets-v7" for vector tiles.
 		/// </summary>
-		/// <value> 
-		///     The tileset map ID, usually in the format "user.mapid". Exceptionally,
+		/// <value>
+		///     The tileset ID, usually in the format "user.mapid". Exceptionally,
 		///     <see cref="T:Mapbox.Map.RasterTile"/> will take the full style URL
 		///     from where the tile is composited from, like "mapbox://styles/mapbox/streets-v9".
 		/// </value>
-		public string MapId
+		public string TilesetId
 		{
 			get
 			{
-				return this.mapId;
+				return this.tilesetId;
 			}
 
 			set
 			{
-				if (this.mapId == value)
+				if (this.tilesetId == value)
 				{
 					return;
 				}
 
-				this.mapId = value;
+				this.tilesetId = value;
 
 				foreach (Tile tile in this.tiles)
 				{
@@ -224,12 +224,12 @@ namespace Mapbox.Map
 
 				Tile.Parameters param;
 				param.Id = id;
-				param.MapId = this.mapId;
+				param.TilesetId = this.tilesetId;
 				param.Fs = this.fs;
 
 				tile.Initialize(param, () => { this.NotifyNext(tile); });
 
-				this.tiles.Add(tile);				
+				this.tiles.Add(tile);
 			}
 		}
 	}

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/MapUtils.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/MapUtils.cs
@@ -43,11 +43,11 @@ namespace Mapbox.Map
 		}
 
 		/// <summary>
-		/// Converts a MapId to a URL.
+		/// Converts a TilesetId to a URL.
 		/// </summary>
 		/// <returns>The identifier to URL.</returns>
 		/// <param name="id">The style id.</param>
-		public static string MapIdToUrl(string id)
+		public static string TilesetIdToUrl(string id)
 		{
 			// TODO: Validate that id is a real id
 			const string MapBaseApi = Constants.BaseAPI + "v4/";

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RasterTile.cs
@@ -16,9 +16,9 @@ namespace Mapbox.Map
 	/// var parameters = new Tile.Parameters();
 	/// parameters.Fs = MapboxAccess.Instance;
 	/// parameters.Id = new CanonicalTileId(_zoom, _tileCoorindateX, _tileCoordinateY);
-	/// parameters.MapId = "mapbox://styles/mapbox/satellite-v9";
+	/// parameters.TilesetId = "mapbox://styles/mapbox/satellite-v9";
 	/// var rasterTile = new RasterTile();
-	/// 
+	///
 	/// // Make the request.
 	/// rasterTile.Initialize(parameters, (Action)(() =>
 	/// {
@@ -26,7 +26,7 @@ namespace Mapbox.Map
 	/// 	{
 	///			// Handle the error.
 	///		}
-	/// 
+	///
 	/// 	// Consume the <see cref="Data"/>.
 	///	}));
 	/// </code>
@@ -37,7 +37,7 @@ namespace Mapbox.Map
 
 		/// <summary> Gets the raster tile raw data. </summary>
 		/// <value> The raw data, usually an encoded JPEG or PNG. </value>
-		/// <example> 
+		/// <example>
 		/// Consuming data in Unity to create a Texture2D:
 		/// <code>
 		/// var texture = new Texture2D(0, 0);
@@ -53,9 +53,9 @@ namespace Mapbox.Map
 			}
 		}
 
-		internal override TileResource MakeTileResource(string styleUrl)
+		internal override TileResource MakeTileResource(string tilesetId)
 		{
-			return TileResource.MakeRaster(Id, styleUrl);
+			return TileResource.MakeRaster(Id, tilesetId);
 		}
 
 		internal override bool ParseTileData(byte[] data)

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RawPngRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RawPngRasterTile.cs
@@ -28,9 +28,9 @@ namespace Mapbox.Map
 	/// </example>
 	public sealed class RawPngRasterTile : RasterTile
 	{
-		internal override TileResource MakeTileResource(string mapId)
+		internal override TileResource MakeTileResource(string tilesetId)
 		{
-			return TileResource.MakeRawPngRaster(Id, mapId);
+			return TileResource.MakeRawPngRaster(Id, tilesetId);
 		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RetinaRasterTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/RetinaRasterTile.cs
@@ -14,9 +14,9 @@ namespace Mapbox.Map
     /// </summary>
     public class RetinaRasterTile : RasterTile
     {
-        internal override TileResource MakeTileResource(string mapId)
+        internal override TileResource MakeTileResource(string tilesetId)
         {
-            return TileResource.MakeRetinaRaster(Id, mapId);
+            return TileResource.MakeRetinaRaster(Id, tilesetId);
         }
     }
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Tile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/Tile.cs
@@ -131,17 +131,17 @@ namespace Mapbox.Map
 			_state = State.Loading;
 			_id = param.Id;
 			_callback = callback;
-			_request = param.Fs.Request(MakeTileResource(param.MapId).GetUrl(), HandleTileResponse, tileId: _id, mapId: param.MapId);
+			_request = param.Fs.Request(MakeTileResource(param.TilesetId).GetUrl(), HandleTileResponse, tileId: _id, tilesetId: param.TilesetId);
 		}
 
-		internal void Initialize(IFileSource fileSource, CanonicalTileId canonicalTileId, string mapId, Action p)
+		internal void Initialize(IFileSource fileSource, CanonicalTileId canonicalTileId, string tilesetId, Action p)
 		{
 			Cancel();
 
 			_state = State.Loading;
 			_id = canonicalTileId;
 			_callback = p;
-			_request = fileSource.Request(MakeTileResource(mapId).GetUrl(), HandleTileResponse, tileId: _id, mapId: mapId);
+			_request = fileSource.Request(MakeTileResource(tilesetId).GetUrl(), HandleTileResponse, tileId: _id, tilesetId: tilesetId);
 		}
 
 		/// <summary>
@@ -177,7 +177,7 @@ namespace Mapbox.Map
 		///		{
 		///			tile.Cancel();
 		///			NotifyNext(tile);
-		///			return true;			
+		///			return true;
 		/// 	}
 		///	});
 		/// </code>
@@ -195,7 +195,7 @@ namespace Mapbox.Map
 
 
 		// Get the tile resource (raster/vector/etc).
-		internal abstract TileResource MakeTileResource(string mapid);
+		internal abstract TileResource MakeTileResource(string tilesetId);
 
 
 		// Decode the tile.
@@ -253,7 +253,7 @@ namespace Mapbox.Map
 		/// var parameters = new Tile.Parameters();
 		/// parameters.Fs = MapboxAccess.Instance;
 		/// parameters.Id = new CanonicalTileId(_zoom, _tileCoorindateX, _tileCoordinateY);
-		/// parameters.MapId = "mapbox.mapbox-streets-v7";
+		/// parameters.TilesetId = "mapbox.mapbox-streets-v7";
 		/// </code>
 		/// </example>
 		public struct Parameters
@@ -262,11 +262,11 @@ namespace Mapbox.Map
 			public CanonicalTileId Id;
 
 			/// <summary>
-			///     The tileset map ID, usually in the format "user.mapid". Exceptionally,
+			///     The tileset ID, usually in the format "user.mapid". Exceptionally,
 			///     <see cref="T:Mapbox.Map.RasterTile"/> will take the full style URL
 			///     from where the tile is composited from, like mapbox://styles/mapbox/streets-v9.
 			/// </summary>
-			public string MapId;
+			public string TilesetId;
 
 			/// <summary> The data source abstraction. </summary>
 			public IFileSource Fs;

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/TileCover.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/TileCover.cs
@@ -35,7 +35,7 @@ namespace Mapbox.Map
 		/// 	var parameters = new Tile.Parameters();
 		/// 	parameters.Id = id;
 		///		parameters.Fs = MapboxAccess.Instance;
-		///		parameters.MapId = "mapbox://styles/mapbox/outdoors-v10";
+		///		parameters.TilesetId = "mapbox://styles/mapbox/outdoors-v10";
 		///		tile.Initialize(parameters, (Action)(() =&gt;
 		///		{
 		///			// Place tiles and load textures.

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/TileResource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/TileResource.cs
@@ -28,29 +28,29 @@ namespace Mapbox.Map
 			return new TileResource(string.Format("{0}/{1}@2x", MapUtils.NormalizeStaticStyleURL(styleUrl ?? "mapbox://styles/mapbox/satellite-v9"), id));
 		}
 
-		public static TileResource MakeClassicRaster(CanonicalTileId id, string mapId)
+		public static TileResource MakeClassicRaster(CanonicalTileId id, string tilesetId)
 		{
-			return new TileResource(string.Format("{0}/{1}.png", MapUtils.MapIdToUrl(mapId ?? "mapbox.satellite"), id));
+			return new TileResource(string.Format("{0}/{1}.png", MapUtils.TilesetIdToUrl(tilesetId ?? "mapbox.satellite"), id));
 		}
 
-		internal static TileResource MakeClassicRetinaRaster(CanonicalTileId id, string mapId)
+		internal static TileResource MakeClassicRetinaRaster(CanonicalTileId id, string tilesetId)
 		{
-			return new TileResource(string.Format("{0}/{1}@2x.png", MapUtils.MapIdToUrl(mapId ?? "mapbox.satellite"), id));
+			return new TileResource(string.Format("{0}/{1}@2x.png", MapUtils.TilesetIdToUrl(tilesetId ?? "mapbox.satellite"), id));
 		}
 
-		public static TileResource MakeRawPngRaster(CanonicalTileId id, string mapId)
+		public static TileResource MakeRawPngRaster(CanonicalTileId id, string tilesetId)
 		{
-			return new TileResource(string.Format("{0}/{1}.pngraw", MapUtils.MapIdToUrl(mapId ?? "mapbox.terrain-rgb"), id));
+			return new TileResource(string.Format("{0}/{1}.pngraw", MapUtils.TilesetIdToUrl(tilesetId ?? "mapbox.terrain-rgb"), id));
 		}
 
-		public static TileResource MakeVector(CanonicalTileId id, string mapId)
+		public static TileResource MakeVector(CanonicalTileId id, string tilesetId)
 		{
-			return new TileResource(string.Format("{0}/{1}.vector.pbf", MapUtils.MapIdToUrl(mapId ?? "mapbox.mapbox-streets-v7"), id));
+			return new TileResource(string.Format("{0}/{1}.vector.pbf", MapUtils.TilesetIdToUrl(tilesetId ?? "mapbox.mapbox-streets-v7"), id));
 		}
 
-		internal static TileResource MakeStyleOptimizedVector(CanonicalTileId id, string mapId, string optimizedStyleId, string modifiedDate)
+		internal static TileResource MakeStyleOptimizedVector(CanonicalTileId id, string tilesetId, string optimizedStyleId, string modifiedDate)
 		{
-			return new TileResource(string.Format("{0}/{1}.vector.pbf?style={2}@{3}", MapUtils.MapIdToUrl(mapId ?? "mapbox.mapbox-streets-v7"), id, optimizedStyleId, modifiedDate));
+			return new TileResource(string.Format("{0}/{1}.vector.pbf?style={2}@{3}", MapUtils.TilesetIdToUrl(tilesetId ?? "mapbox.mapbox-streets-v7"), id, optimizedStyleId, modifiedDate));
 		}
 
 		public string GetUrl()

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/VectorTile.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Map/VectorTile.cs
@@ -15,7 +15,7 @@ namespace Mapbox.Map
 	/// <summary>
 	///    A decoded vector tile, as specified by the
 	///    <see href="https://www.mapbox.com/vector-tiles/specification/">
-	///    Mapbox Vector Tile specification</see>. 
+	///    Mapbox Vector Tile specification</see>.
 	///    See available layers and features <see href="https://www.mapbox.com/vector-tiles/mapbox-streets-v7/">here</see>.
 	///    The tile might be incomplete if the network request and parsing are still pending.
 	/// </summary>
@@ -25,9 +25,9 @@ namespace Mapbox.Map
 	/// var parameters = new Tile.Parameters();
 	/// parameters.Fs = MapboxAccess.Instance;
 	/// parameters.Id = new CanonicalTileId(_zoom, _tileCoorindateX, _tileCoordinateY);
-	/// parameters.MapId = "mapbox.mapbox-streets-v7";
+	/// parameters.TilesetId = "mapbox.mapbox-streets-v7";
 	/// var vectorTile = new VectorTile();
-	/// 
+	///
 	/// // Make the request.
 	/// vectorTile.Initialize(parameters, (Action)(() =>
 	/// {
@@ -35,7 +35,7 @@ namespace Mapbox.Map
 	/// 	{
 	///			// Handle the error.
 	///		}
-	/// 
+	///
 	/// 	// Consume the <see cref="Data"/>.
 	///	}));
 	/// </code>
@@ -182,12 +182,12 @@ namespace Mapbox.Map
 		}
 
 
-		internal override TileResource MakeTileResource(string mapId)
+		internal override TileResource MakeTileResource(string tilesetId)
 		{
 
 			return (_isStyleOptimized) ?
-				TileResource.MakeStyleOptimizedVector(Id, mapId, _optimizedStyleId, _modifiedDate)
-			  : TileResource.MakeVector(Id, mapId);
+				TileResource.MakeStyleOptimizedVector(Id, tilesetId, _optimizedStyleId, _modifiedDate)
+			  : TileResource.MakeVector(Id, tilesetId);
 		}
 
 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CachingWebFileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CachingWebFileSource.cs
@@ -113,13 +113,13 @@
 			, Action<Response> callback
 			, int timeout = 10
 			, CanonicalTileId tileId = new CanonicalTileId()
-			, string mapId = null
+			, string tilesetId = null
 		)
 		{
 
-			if (string.IsNullOrEmpty(mapId))
+			if (string.IsNullOrEmpty(tilesetId))
 			{
-				throw new Exception("Cannot cache without a map id");
+				throw new Exception("Cannot cache without a tileset id");
 			}
 
 			CacheItem cachedItem = null;
@@ -127,7 +127,7 @@
 			// go through existing caches and check if we already have the requested tile available
 			foreach (var cache in _caches)
 			{
-				cachedItem = cache.Get(mapId, tileId);
+				cachedItem = cache.Get(tilesetId, tileId);
 				if (null != cachedItem)
 				{
 					break;
@@ -157,7 +157,7 @@
 			if (null != cachedItem)
 			{
 #if MAPBOX_DEBUG_CACHE
-				UnityEngine.Debug.LogFormat("{0} {1} {2} {3}", methodName, mapId, tileId, null != cachedItem.Data ? cachedItem.Data.Length.ToString() : "cachedItem.Data is NULL");
+				UnityEngine.Debug.LogFormat("{0} {1} {2} {3}", methodName, tilesetId, tileId, null != cachedItem.Data ? cachedItem.Data.Length.ToString() : "cachedItem.Data is NULL");
 #endif
 				// immediately return cached tile
 				callback(Response.FromCache(cachedItem.Data));
@@ -193,24 +193,24 @@
 							{
 								foreach (var cache in _caches)
 								{
-									cache.Add(mapId, tileId, cachedItem, false);
+									cache.Add(tilesetId, tileId, cachedItem, false);
 								}
 							}
 							else
 							{
 								// TODO: remove Debug.Log before PR
 								UnityEngine.Debug.LogWarningFormat(
-										"updating cached tile {1} mapid:{2}{0}cached etag:{3}{0}remote etag:{4}{0}{5}"
+										"updating cached tile {1} tilesetId:{2}{0}cached etag:{3}{0}remote etag:{4}{0}{5}"
 										, Environment.NewLine
 										, tileId
-										, mapId
+										, tilesetId
 										, cachedItem.ETag
 										, headerOnly.Headers["ETag"]
 										, finalUrl
 									);
 
 								// request updated tile and pass callback to return new data to subscribers
-								requestTileAndCache(finalUrl, mapId, tileId, timeout, callback);
+								requestTileAndCache(finalUrl, tilesetId, tileId, timeout, callback);
 							}
 						}
 						, timeout
@@ -224,14 +224,14 @@
 			{
 				// requested tile is not in any of the caches yet, get it
 #if MAPBOX_DEBUG_CACHE
-				UnityEngine.Debug.LogFormat("{0} {1} {2} not cached", methodName, mapId, tileId);
+				UnityEngine.Debug.LogFormat("{0} {1} {2} not cached", methodName, tilesetId, tileId);
 #endif
-				return requestTileAndCache(finalUrl, mapId, tileId, timeout, callback);
+				return requestTileAndCache(finalUrl, tilesetId, tileId, timeout, callback);
 			}
 		}
 
 
-		private IAsyncRequest requestTileAndCache(string url, string mapId, CanonicalTileId tileId, int timeout, Action<Response> callback)
+		private IAsyncRequest requestTileAndCache(string url, string tilesetId, CanonicalTileId tileId, int timeout, Action<Response> callback)
 		{
 			return IAsyncRequestFactory.CreateRequest(
 				url,
@@ -263,7 +263,7 @@
 						foreach (var cache in _caches)
 						{
 							cache.Add(
-								mapId
+								tilesetId
 								, tileId
 								, new CacheItem()
 								{

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/ICache.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/ICache.cs
@@ -10,7 +10,7 @@ namespace Mapbox.Platform.Cache
 	{
 
 		/// <summary>
-		/// Maximum number of tiles to store 
+		/// Maximum number of tiles to store
 		/// </summary>
 		uint MaxCacheSize { get; }
 
@@ -18,20 +18,20 @@ namespace Mapbox.Platform.Cache
 		/// <summary>
 		/// Add tile data to the cache
 		/// </summary>
-		/// <param name="mapId">Tile set name</param>
-		/// <param name="tileId">Tile ID</param>
+		/// <param name="tilesetId">Tile set name</param>
+		/// <param name="tileId</param>
 		/// <param name="item">Item to cache</param>
 		/// <param name="replaceIfExists">Force insert even if item already exists.</param>
-		void Add(string mapId, CanonicalTileId tileId, CacheItem item, bool replaceIfExists);
+		void Add(string tilesetId, CanonicalTileId tileId, CacheItem item, bool replaceIfExists);
 
 
 		/// <summary>
 		/// Get tile
 		/// </summary>
-		/// <param name="mapId"></param>
+		/// <param name="tilesetId"></param>
 		/// <param name="tileId"></param>
 		/// <returns>byte[] with tile data. Null if requested tile is not in cache</returns>
-		CacheItem Get(string mapId, CanonicalTileId tileId);
+		CacheItem Get(string tilesetId, CanonicalTileId tileId);
 
 
 		/// <summary>Clear cache for all tile sets</summary>
@@ -41,8 +41,8 @@ namespace Mapbox.Platform.Cache
 		/// <summary>
 		/// Clear cache for one tile set
 		/// </summary>
-		/// <param name="mapId"></param>
-		void Clear(string mapId);
+		/// <param name="tilesetId"></param>
+		void Clear(string tilesetId);
 
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/MemoryCache.cs
@@ -43,9 +43,9 @@ namespace Mapbox.Platform.Cache
 		}
 
 
-		public void Add(string mapdId, CanonicalTileId tileId, CacheItem item, bool forceInsert)
+		public void Add(string mapdId, CanonicalTileId tilesetId, CacheItem item, bool forceInsert)
 		{
-			string key = mapdId + "||" + tileId;
+			string key = mapdId + "||" + tilesetId;
 
 			lock (_lock)
 			{
@@ -64,9 +64,9 @@ namespace Mapbox.Platform.Cache
 		}
 
 
-		public CacheItem Get(string mapId, CanonicalTileId tileId)
+		public CacheItem Get(string tilesetId, CanonicalTileId tileId)
 		{
-			string key = mapId + "||" + tileId;
+			string key = tilesetId + "||" + tileId;
 
 #if MAPBOX_DEBUG_CACHE
 			string methodName = _className + "." + new System.Diagnostics.StackFrame().GetMethod().Name;
@@ -94,12 +94,12 @@ namespace Mapbox.Platform.Cache
 		}
 
 
-		public void Clear(string mapId)
+		public void Clear(string tilesetId)
 		{
 			lock (_lock)
 			{
-				mapId += "||";
-				List<string> toDelete = _cachedResponses.Keys.Where(k => k.Contains(mapId)).ToList();
+				tilesetId += "||";
+				List<string> toDelete = _cachedResponses.Keys.Where(k => k.Contains(tilesetId)).ToList();
 				foreach (string key in toDelete)
 				{
 					_cachedResponses.Remove(key);

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
@@ -79,7 +79,7 @@ namespace Mapbox.Platform
 			, Action<Response> callback
 			, int timeout = 10
 			, CanonicalTileId tileId = new CanonicalTileId()
-			, string mapId = null
+			, string tilesetId = null
 		)
 		{
 			if (!string.IsNullOrEmpty(_accessToken))
@@ -109,7 +109,7 @@ namespace Mapbox.Platform
 
 			//return request;
 
-			return proxyResponse(url, callback, timeout, tileId, mapId);
+			return proxyResponse(url, callback, timeout, tileId, tilesetId);
 		}
 
 
@@ -120,7 +120,7 @@ namespace Mapbox.Platform
 			, Action<Response> callback
 			, int timeout
 			, CanonicalTileId tileId
-			, string mapId
+			, string tilesetId
 		)
 		{
 

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/IFileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/IFileSource.cs
@@ -25,6 +25,6 @@ namespace Mapbox.Platform
 		///     request. This handle can be completely ignored if there is no intention of ever
 		///     canceling the request.
 		/// </returns>
-		IAsyncRequest Request(string uri, Action<Response> callback, int timeout = 10, CanonicalTileId tileId = new CanonicalTileId(), string mapId = null);
+		IAsyncRequest Request(string uri, Action<Response> callback, int timeout = 10, CanonicalTileId tileId = new CanonicalTileId(), string tilesetId = null);
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/MapboxUnitTests_Map.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Tests/UnitTests/Editor/MapboxUnitTests_Map.cs
@@ -45,7 +45,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 		public IEnumerator World()
 #else
 		[Test]
-		public void World() 
+		public void World()
 #endif
 		{
 			var map = new Map<VectorTile>(_fs);
@@ -76,7 +76,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 		public IEnumerator RasterHelsinki()
 #else
 		[Test]
-		public void RasterHelsinki() 
+		public void RasterHelsinki()
 #endif
 		{
 			var map = new Map<RasterTile>(_fs);
@@ -105,10 +105,10 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 
 #if UNITY_5_6_OR_NEWER
 		[UnityTest]
-		public IEnumerator ChangeMapId()
+		public IEnumerator ChangeTilesetId()
 #else
 		[Test]
-		public void ChangeMapId() 
+		public void ChangeTilesetId()
 #endif
 		{
 			var map = new Map<ClassicRasterTile>(_fs);
@@ -118,7 +118,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 
 			map.Center = new Vector2d(60.163200, 24.937700);
 			map.Zoom = 13;
-			map.MapId = "invalid";
+			map.TilesetId = "invalid";
 			map.Update();
 
 #if UNITY_5_6_OR_NEWER
@@ -130,7 +130,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 
 			Assert.AreEqual(0, mapObserver.Tiles.Count);
 
-			map.MapId = "mapbox.terrain-rgb";
+			map.TilesetId = "mapbox.terrain-rgb";
 			map.Update();
 
 #if UNITY_5_6_OR_NEWER
@@ -142,7 +142,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 
 			Assert.AreEqual(1, mapObserver.Tiles.Count);
 
-			map.MapId = null; // Use default map ID.
+			map.TilesetId = null; // Use default tileset ID.
 			map.Update();
 
 #if UNITY_5_6_OR_NEWER
@@ -154,7 +154,7 @@ namespace Mapbox.MapboxSdkCs.UnitTest
 
 			Assert.AreEqual(2, mapObserver.Tiles.Count);
 
-			// Should have fetched tiles from different map IDs.
+			// Should have fetched tiles from different tileset IDs.
 			Assert.AreNotEqual(mapObserver.Tiles[0], mapObserver.Tiles[1]);
 
 			map.Unsubscribe(mapObserver);

--- a/sdkproject/Assets/Mapbox/Examples/5_Playground/Scripts/RasterTileExample.cs
+++ b/sdkproject/Assets/Mapbox/Examples/5_Playground/Scripts/RasterTileExample.cs
@@ -74,7 +74,7 @@ namespace Mapbox.Examples.Playground
 		void Start()
 		{
 			_map = new Map<RasterTile>(MapboxAccess.Instance);
-			_map.MapId = _mapboxStyles[_mapstyle];
+			_map.TilesetId = _mapboxStyles[_mapstyle];
 			_map.Center = _startLoc;
 			_map.Zoom = (int)_zoomSlider.value;
 			_map.Subscribe(this);
@@ -109,7 +109,7 @@ namespace Mapbox.Examples.Playground
 		void ToggleDropdownStyles(int target)
 		{
 			_mapstyle = target;
-			_map.MapId = _mapboxStyles[target];
+			_map.TilesetId = _mapboxStyles[target];
 			_map.Update();
 		}
 

--- a/sdkproject/Assets/Mapbox/Examples/8_VoxelMap/Scripts/VoxelTile.cs
+++ b/sdkproject/Assets/Mapbox/Examples/8_VoxelMap/Scripts/VoxelTile.cs
@@ -76,9 +76,9 @@ namespace Mapbox.Examples.Voxels
 
 			if (!string.IsNullOrEmpty(_styleUrl))
 			{
-				_raster.MapId = _styleUrl;
+				_raster.TilesetId = _styleUrl;
 			}
-			_elevation.MapId = "mapbox.terrain-rgb";
+			_elevation.TilesetId = "mapbox.terrain-rgb";
 
 			_elevation.Subscribe(this);
 			_raster.Subscribe(this);

--- a/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/MapManagerEditor.cs
@@ -89,10 +89,10 @@ namespace Mapbox.Editor
 			}
 		}
 
-		private GUIContent mapIdGui = new GUIContent
+		private GUIContent tilesetIdGui = new GUIContent
 		{
-			text = "Map Id",
-			tooltip = "Map Id corresponding to the tileset."
+			text = "Tileset Id",
+			tooltip = "Id of the tileset."
 		};
 
 		bool _isGUIContentSet = false;
@@ -327,12 +327,12 @@ namespace Mapbox.Editor
 					var sourcePropertyValue = MapboxDefaultVector.GetParameters(sourceTypeValue);
 					layerSourceId.stringValue = sourcePropertyValue.Id;
 					GUI.enabled = false;
-					EditorGUILayout.PropertyField(layerSourceProperty, mapIdGui);
+					EditorGUILayout.PropertyField(layerSourceProperty, tilesetIdGui);
 					GUI.enabled = true;
 					isActiveProperty.boolValue = true;
 					break;
 				case VectorSourceType.Custom:
-					EditorGUILayout.PropertyField(layerSourceProperty, mapIdGui);
+					EditorGUILayout.PropertyField(layerSourceProperty, tilesetIdGui);
 					isActiveProperty.boolValue = true;
 					break;
 				case VectorSourceType.None:

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ElevationLayerPropertiesDrawer.cs
@@ -25,21 +25,21 @@
 			}
 		}
 
-		private GUIContent _mapIdGui = new GUIContent
+		private GUIContent _tilesetIdGui = new GUIContent
 		{
-			text = "Map Id",
-			tooltip = "Map Id corresponding to the tileset."
+			text = "Tileset Id",
+			tooltip = "Id of the tileset."
 		};
 
-		string CustomSourceMapId
+		string CustomSourceTilesetId
 		{
 			get
 			{
-				return EditorPrefs.GetString(objectId + "ElevationLayerProperties_customSourceMapId");
+				return EditorPrefs.GetString(objectId + "ElevationLayerProperties_customSourceTilesetId");
 			}
 			set
 			{
-				EditorPrefs.SetString(objectId + "ElevationLayerProperties_customSourceMapId", value);
+				EditorPrefs.SetString(objectId + "ElevationLayerProperties_customSourceTilesetId", value);
 			}
 		}
 
@@ -87,13 +87,13 @@
 					var sourcePropertyValue = MapboxDefaultElevation.GetParameters(sourceTypeValue);
 					layerSourceId.stringValue = sourcePropertyValue.Id;
 					GUI.enabled = false;
-					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
+					EditorGUILayout.PropertyField(sourceOptionsProperty, _tilesetIdGui);
 					GUI.enabled = true;
 					break;
 				case ElevationSourceType.Custom:
-					layerSourceId.stringValue = string.IsNullOrEmpty(CustomSourceMapId) ? MapboxDefaultElevation.GetParameters(ElevationSourceType.MapboxTerrain).Id : CustomSourceMapId;
-					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
-					CustomSourceMapId = layerSourceId.stringValue;
+					layerSourceId.stringValue = string.IsNullOrEmpty(CustomSourceTilesetId) ? MapboxDefaultElevation.GetParameters(ElevationSourceType.MapboxTerrain).Id : CustomSourceTilesetId;
+					EditorGUILayout.PropertyField(sourceOptionsProperty, _tilesetIdGui);
+					CustomSourceTilesetId = layerSourceId.stringValue;
 					break;
 				default:
 					break;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/FeaturesSubLayerPropertiesDrawer.cs
@@ -145,7 +145,7 @@
 					}
 					if (tileJSONData.PropertyDisplayNames.Count == 0 && tileJSONData.tileJSONLoaded)
 					{
-						EditorGUILayout.HelpBox("Invalid Map Id / There might be a problem with the internet connection.", MessageType.Error);
+						EditorGUILayout.HelpBox("Invalid Tileset Id / There might be a problem with the internet connection.", MessageType.Error);
 					}
 					GUI.enabled = true;
 					isActiveProperty.boolValue = true;
@@ -162,7 +162,7 @@
 					}
 					if (tileJSONData.PropertyDisplayNames.Count == 0 && tileJSONData.tileJSONLoaded)
 					{
-						EditorGUILayout.HelpBox("Invalid Map Id / There might be a problem with the internet connection.", MessageType.Error);
+						EditorGUILayout.HelpBox("Invalid Tileset Id / There might be a problem with the internet connection.", MessageType.Error);
 					}
 					isActiveProperty.boolValue = true;
 					break;
@@ -609,7 +609,7 @@
 			//disable the selection if there is no layer
 			if (layerDisplayNames.Count == 0)
 			{
-				EditorGUILayout.LabelField(layerNameLabel, new GUIContent("No layers found: Invalid MapId / No Internet."), (GUIStyle)"minipopUp");
+				EditorGUILayout.LabelField(layerNameLabel, new GUIContent("No layers found: Invalid TilesetId / No Internet."), (GUIStyle)"minipopUp");
 				return;
 			}
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/ImageryLayerPropertiesDrawer.cs
@@ -11,10 +11,10 @@
 		GUIContent[] sourceTypeContent;
 		bool isGUIContentSet = false;
 
-		private GUIContent _mapIdGui = new GUIContent
+		private GUIContent _tilesetIdGui = new GUIContent
 		{
-			text = "Map Id",
-			tooltip = "Map Id corresponding to the tileset."
+			text = "Tileset Id",
+			tooltip = "Id of the tileset."
 		};
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -66,11 +66,11 @@
 					var sourcePropertyValue = MapboxDefaultImagery.GetParameters(sourceTypeValue);
 					layerSourceId.stringValue = sourcePropertyValue.Id;
 					GUI.enabled = false;
-					EditorGUILayout.PropertyField(sourceOptionsProperty, _mapIdGui);
+					EditorGUILayout.PropertyField(sourceOptionsProperty, _tilesetIdGui);
 					GUI.enabled = true;
 					break;
 				case ImagerySourceType.Custom:
-					EditorGUILayout.PropertyField(sourceOptionsProperty, new GUIContent { text = "Map Id / Style URL", tooltip = _mapIdGui.tooltip });
+					EditorGUILayout.PropertyField(sourceOptionsProperty, new GUIContent { text = "Tileset Id / Style URL", tooltip = _tilesetIdGui.tooltip });
 					break;
 				case ImagerySourceType.None:
 					break;

--- a/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/PropertyDrawers/VectorLayerPropertiesDrawer.cs
@@ -40,9 +40,9 @@
 			}
 		}
 
-		private GUIContent _requiredMapIdGui = new GUIContent
+		private GUIContent _requiredTilesetIdGui = new GUIContent
 		{
-			text = "Required Map Id",
+			text = "Required Tileset Id",
 			tooltip = "For location prefabs to spawn the \"streets-v7\" tileset needs to be a part of the Vector data source"
 		};
 
@@ -80,7 +80,7 @@
 				if (sourceTypeValue != VectorSourceType.None && layerString.Contains(streets_v7))
 				{
 					GUI.enabled = false;
-					EditorGUILayout.TextField(_requiredMapIdGui, streets_v7);
+					EditorGUILayout.TextField(_requiredTilesetIdGui, streets_v7);
 					GUI.enabled = true;
 					_poiSublayerDrawer.DrawUI(property);
 				}
@@ -92,7 +92,7 @@
 
 			ShowSepartor();
 
-			//Draw Feature section. 
+			//Draw Feature section.
 			ShowFeatures = EditorGUILayout.Foldout(ShowFeatures, "FEATURES");
 			if (ShowFeatures)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MapboxAccess.cs
@@ -225,10 +225,10 @@ namespace Mapbox.Unity
 			, Action<Response> callback
 			, int timeout = 10
 			, CanonicalTileId tileId = new CanonicalTileId()
-			, string mapId = null
+			, string tilesetId = null
 		)
 		{
-			return _fileSource.Request(url, callback, _configuration.DefaultTimeout, tileId, mapId);
+			return _fileSource.Request(url, callback, _configuration.DefaultTimeout, tileId, tilesetId);
 		}
 
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/ImageDataFetcher.cs
@@ -18,7 +18,7 @@ public class ImageDataFetcher : DataFetcher
 			return;
 		}
 		RasterTile rasterTile;
-		if (imageDataParameters.mapid.StartsWith("mapbox://", StringComparison.Ordinal))
+		if (imageDataParameters.tilesetId.StartsWith("mapbox://", StringComparison.Ordinal))
 		{
 			rasterTile = imageDataParameters.useRetina ? new RetinaRasterTile() : new RasterTile();
 		}
@@ -32,7 +32,7 @@ public class ImageDataFetcher : DataFetcher
 			imageDataParameters.tile.AddTile(rasterTile);
 		}
 
-		rasterTile.Initialize(_fileSource, imageDataParameters.tile.CanonicalTileId, imageDataParameters.mapid, () =>
+		rasterTile.Initialize(_fileSource, imageDataParameters.tile.CanonicalTileId, imageDataParameters.tilesetId, () =>
 		{
 			if (imageDataParameters.tile.CanonicalTileId != rasterTile.Id)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/MapImageFactory.cs
@@ -34,7 +34,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			}
 		}
 
-		public string MapId
+		public string TilesetId
 		{
 			get
 			{
@@ -121,7 +121,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				{
 					canonicalTileId = tile.CanonicalTileId,
 					tile = tile,
-					mapid = MapId,
+					tilesetId = TilesetId,
 					useRetina = _properties.rasterOptions.useRetina
 				};
 				DataFetcher.FetchData(parameters);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainDataFetcher.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 public class DataFetcherParameters
 {
 	public CanonicalTileId canonicalTileId;
-	public string mapid;
+	public string tilesetId;
 	public UnityTile tile;
 }
 
@@ -53,10 +53,10 @@ public class TerrainDataFetcher : DataFetcher
 		var terrainDataParameters = parameters as TerrainDataFetcherParameters;
 		if(terrainDataParameters == null)
 		{
-			return;	
+			return;
 		}
 		var pngRasterTile = new RawPngRasterTile();
-		pngRasterTile.Initialize(_fileSource, terrainDataParameters.canonicalTileId, terrainDataParameters.mapid, () =>
+		pngRasterTile.Initialize(_fileSource, terrainDataParameters.canonicalTileId, terrainDataParameters.tilesetId, () =>
 		{
 			if (terrainDataParameters.tile.CanonicalTileId != pngRasterTile.Id)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainFactoryBase.cs
@@ -74,7 +74,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				TerrainDataFetcherParameters parameters = new TerrainDataFetcherParameters()
 				{
 					canonicalTileId = tile.CanonicalTileId,
-					mapid = _elevationOptions.sourceOptions.Id,
+					tilesetId = _elevationOptions.sourceOptions.Id,
 					tile = tile
 				};
 				DataFetcher.FetchData(parameters);

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorDataFetcher.cs
@@ -18,7 +18,7 @@ public class VectorDataFetcher : DataFetcher
 		}
 		var vectorTile = (vectorDaraParameters.useOptimizedStyle) ? new VectorTile(vectorDaraParameters.style.Id, vectorDaraParameters.style.Modified) : new VectorTile();
 		vectorDaraParameters.tile.AddTile(vectorTile);
-		vectorTile.Initialize(_fileSource, vectorDaraParameters.tile.CanonicalTileId, vectorDaraParameters.mapid, () =>
+		vectorTile.Initialize(_fileSource, vectorDaraParameters.tile.CanonicalTileId, vectorDaraParameters.tilesetId, () =>
 		{
 			if (vectorDaraParameters.tile.CanonicalTileId != vectorTile.Id)
 			{

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -34,7 +34,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 		#endregion
 
 		#region Properties
-		public string MapId
+		public string TilesetId
 		{
 			get
 			{
@@ -192,7 +192,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 
 		protected override void OnRegistered(UnityTile tile)
 		{
-			if (string.IsNullOrEmpty(MapId) || _properties.sourceOptions.isActive == false || (_properties.vectorSubLayers.Count + _properties.locationPrefabList.Count) == 0)
+			if (string.IsNullOrEmpty(TilesetId) || _properties.sourceOptions.isActive == false || (_properties.vectorSubLayers.Count + _properties.locationPrefabList.Count) == 0)
 			{
 				tile.VectorDataState = TilePropertyState.None;
 				return;
@@ -202,7 +202,7 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 			VectorDataFetcherParameters parameters = new VectorDataFetcherParameters()
 			{
 				canonicalTileId = tile.CanonicalTileId,
-				mapid = MapId,
+				tilesetId = TilesetId,
 				tile = tile,
 				useOptimizedStyle = _properties.useOptimizedStyle,
 				style = _properties.optimizedStyle

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/IImageryLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/IImageryLayer.cs
@@ -10,7 +10,7 @@
 		/// <summary>
 		/// Sets the `Data Source` for the `IMAGE` component. This can be one of the
 		/// [Mapbox default styles](https://www.mapbox.com/api-documentation/maps/#styles),
-		/// or a custom style. The style url is set as the `Map ID`.
+		/// or a custom style. The style url is set as the `Tileset ID`.
 		/// </summary>
 		/// <param name="imageSource">Source of imagery for map. Can be a Mapbox default, or custom style.</param>
 		void SetLayerSource(ImagerySourceType imageSource);

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/ILayer.cs
@@ -47,11 +47,11 @@ namespace Mapbox.Unity.Map
 		void SetLayerSource(VectorSourceType vectorSource);
 
 		/// <summary>
-		/// Adds the provided `Data Source` (`Map ID`) to existing ones. For multiple
-		/// sources, you can separate with a comma. `Map ID` string is added at the
+		/// Adds the provided `Data Source` (`Tileset ID`) to existing ones. For multiple
+		/// sources, you can separate with a comma. `Tileset ID` string is added at the
 		/// end of the existing sources.
 		/// </summary>
-		/// <param name="vectorSource">`Data Source` (`Map ID`) to add to existing sources.</param>
+		/// <param name="vectorSource">`Data Source` (`Tileset ID`) to add to existing sources.</param>
 		void AddLayerSource(string vectorSource);
 
 		/// <summary>

--- a/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/SourceLayers/VectorLayer.cs
@@ -158,11 +158,11 @@ namespace Mapbox.Unity.Map
 		}
 
 		/// <summary>
-		/// Add provided data source (mapid) to existing ones.
-		/// Mapbox vector api supports comma separated mapids and this method
-		/// adds the provided mapid at the end of the existing source.
+		/// Add provided data source (TilesetId) to existing ones.
+		/// Mapbox vector api supports comma separated TilesetIds and this method
+		/// adds the provided TilesetId at the end of the existing source.
 		/// </summary>
-		/// <param name="vectorSource">Data source (Mapid) to add to existing sources.</param>
+		/// <param name="vectorSource">Data source (TilesetId) to add to existing sources.</param>
 		public virtual void AddLayerSource(string vectorSource)
 		{
 			if (!string.IsNullOrEmpty(vectorSource))
@@ -185,9 +185,9 @@ namespace Mapbox.Unity.Map
 		}
 
 		/// <summary>
-		/// Change existing data source (mapid) with provided source.
+		/// Change existing data source (TilesetId) with provided source.
 		/// </summary>
-		/// <param name="vectorSource">Data source (Mapid) to use.</param>
+		/// <param name="vectorSource">Data source (TilesetId) to use.</param>
 		public virtual void SetLayerSource(string vectorSource)
 		{
 			SetLayerSourceInternal(vectorSource);
@@ -195,9 +195,9 @@ namespace Mapbox.Unity.Map
 		}
 
 		/// <summary>
-		/// Change existing data source (mapid) with provided source.
+		/// Change existing data source (TilesetId) with provided source.
 		/// </summary>
-		/// <param name="vectorSource">Data source (Mapid) to use.</param>
+		/// <param name="vectorSource">Data source (TilesetId) to use.</param>
 		public virtual void SetLayerSource(VectorSourceType vectorSource)
 		{
 			SetLayerSourceInternal(vectorSource);


### PR DESCRIPTION
we're changing `mapid` to `tilesetid` on all platforms. this PR changes all instanced of mapid both in UI and code (and comments). I think there's only two references to mapid is left and they are in some comments about javascript object/path equivalent so I didn't touch those. 

@atripathi-mb @jordy-isaac 