### PR TITLE
Replace deprecated TargetGuidByName with GetUnityFrameworkTargetGuid

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_iOS_build.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/Build/Mapbox_iOS_build.cs
@@ -23,7 +23,7 @@ namespace Mapbox.Editor.Build
 
 				var file = File.ReadAllText(projPath);
 				proj.ReadFromString(file);
-				string target = proj.TargetGuidByName("Unity-iPhone");
+				string target = proj.GetUnityFrameworkTargetGuid();
 
 				var defaultIncludePath = "Mapbox/Core/Plugins/iOS/MapboxMobileEvents/include";
 				var includePaths = Directory.GetDirectories(Application.dataPath, "include", SearchOption.AllDirectories);


### PR DESCRIPTION
**Related issue**

Fixes #1482 

**Description of changes**

Replaces deprecated TargetGuidByName() with GetUnityFrameworkTargetGuid() in Mapbox_iOS_build.cs, fixing broken iOS builds in Unity 2019.x.

**Explanation**

Unity 2019.x deprecates PBXProject.TargetGuidByName(), causing line 26 of Mapbox_iOS_build.cs to throw an editor exception during Unity builds:

`Exception: Calling TargetGuidByName with name='Unity-iPhone' is deprecated. There are two targets now, call GetUnityMainTargetGuid() - for app or GetUnityFrameworkTargetGuid() - for source/plugins to get Guid instead.`

The Unity build will succeed but the Xcode build will fail with the "'MapboxMobileEvents/MapboxMobileEvents.h' file not found" error reported in #1482.

The exception prevents the linking of MapboxMobileEvents and libz.tbd. Replacing TargetGuidByName() with GetUnityFrameworkTargetGuid() avoids the exception and ensures proper linking.