### PR TITLE
Fix flat terrain collider 

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,4 +1,8 @@
 ## CHANGELOG
+### v2.1.2
+### Bug Fixes
+- Fixes a bug where add collider feature didn't work for flat terrain mesh.
+
 ### v2.1.1
 10/15/2019
 ### Bug Fixes

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -73,7 +73,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			{
 				if (_collider == null)
 				{
-					_collider = GetComponent<Collider>();
+					_collider = gameObject.AddComponent<MeshCollider>();
 				}
 				return _collider;
 			}
@@ -268,10 +268,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 					}
 				}
 
-				if (addCollider && gameObject.GetComponent<MeshCollider>() == null)
-				{
-					gameObject.AddComponent<MeshCollider>();
-				}
+
 
 				HeightDataState = TilePropertyState.Loaded;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -73,7 +73,11 @@ namespace Mapbox.Unity.MeshGeneration.Data
 			{
 				if (_collider == null)
 				{
-					_collider = gameObject.AddComponent<MeshCollider>();
+					_collider = gameObject.GetComponent<MeshCollider>();
+					if (_collider == null)
+					{
+						_collider = gameObject.AddComponent<MeshCollider>();
+					}
 				}
 				return _collider;
 			}

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatTerrainStrategy.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/TerrainStrategies/FlatTerrainStrategy.cs
@@ -48,6 +48,15 @@ namespace Mapbox.Unity.MeshGeneration.Factories.TerrainStrategies
 				GetQuad(tile, _elevationOptions.sideWallOptions.isActive);
 				tile.ElevationType = TileTerrainType.Flat;
 			}
+
+			if (_elevationOptions.colliderOptions.addCollider)
+			{
+				var meshCollider = tile.Collider as MeshCollider;
+				if (meshCollider)
+				{
+					meshCollider.sharedMesh = tile.MeshFilter.sharedMesh;
+				}
+			}
 		}
 
 		private void GetQuad(UnityTile tile, bool buildSide)


### PR DESCRIPTION
remove adding mesh collider logic from set height data method as it isn't called for flat terrain

change unity tile collider getter to add component if it's missing (changed getcomponent to addcomponent. it sets the local field directly anyway so unless another source adds the component, this should be fine)
add collider mesh logic to flat terrain strategy (using mesh instead of box collider as mesh collider is the default one for now. can be optimized better)

fixes #1234

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
