### PR TITLE
Vector data processing event fix

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -1,4 +1,8 @@
 ## CHANGELOG
+### v2.1.2
+### Bug Fixes
+- Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+
 ### v2.1.1
 10/15/2019
 ### Bug Fixes

--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -2,6 +2,8 @@
 ### v2.1.2
 ### Bug Fixes
 - Fixes a bug where add collider feature didn't work for flat terrain mesh.
+- Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+
 
 ### v2.1.1
 10/15/2019

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Factories/VectorTileFactory.cs
@@ -328,7 +328,6 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				if (tile.VectorDataState != TilePropertyState.Unregistered)
 				{
 					tile.SetVectorData(vectorTile);
-
 					// FIXME: we can make the request BEFORE getting a response from these!
 					if (tile.HeightDataState == TilePropertyState.Loading ||
 							tile.RasterDataState == TilePropertyState.Loading)
@@ -350,6 +349,8 @@ namespace Mapbox.Unity.MeshGeneration.Factories
 				tile.RasterDataState != TilePropertyState.Loading &&
 				tile.HeightDataState != TilePropertyState.Loading)
 			{
+				tile.OnHeightDataChanged -= DataChangedHandler;
+				tile.OnRasterDataChanged -= DataChangedHandler;
 				CreateMeshes(tile);
 			}
 		}


### PR DESCRIPTION
fix a bug where tile data state checks for vector data processing wasn't cleared

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
