### PR TITLE
Add recycled check to mesh generation 

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/LayerVisualizers/VectorLayerVisualizer.cs
@@ -534,6 +534,11 @@ namespace Mapbox.Unity.MeshGeneration.Interfaces
 						yield break;
 					}
 
+					if (tile.IsRecycled)
+					{
+						yield break;
+					}
+					
 					ProcessFeature(i, tile, tempLayerProperties, layer.Extent);
 
 					if (IsCoroutineBucketFull && !(Application.isEditor && !Application.isPlaying))


### PR DESCRIPTION
We're still experiencing some mesh leaks on very fast tile disposing/reusing cases. 
This is just a small additional check to prevent meshes being generated if the tile is recycled, which rarely happens due to coroutines.