### PR TITLE
Cache expiration fix

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CacheItem.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CacheItem.cs
@@ -15,5 +15,7 @@ namespace Mapbox.Platform.Cache
 		public string ETag;
 		/// <summary> Can be 'null' as not all APIs populated this value. Last-Modified value of API response in GMT: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified </summary>
 		public DateTime? LastModified;
+
+		public DateTime ExpirationDate;
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CachingWebFileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/CachingWebFileSource.cs
@@ -168,13 +168,8 @@ namespace Mapbox.Platform.Cache
 				callback(Response.FromCache(cachedItem.Data));
 
 				// check for updated tiles online if this is enabled in the settings
-				if (cachedItem.ExpirationDate > DateTime.Now)
+				if (cachedItem.ExpirationDate < DateTime.Now)
 				{
-					Debug.Log("not refreshing");
-				}
-				else
-				{
-					Debug.Log("refreshing");
 					// check if tile on the web is newer than the one we already have locally
 					IAsyncRequestFactory.CreateRequest(
 						finalUrl,
@@ -194,14 +189,13 @@ namespace Mapbox.Platform.Cache
 							// additional ETag empty check: for backwards compability with old caches
 							if (response.StatusCode == 304) // 304 NOT MODIFIED
 							{
-								Debug.Log("304");
 								var cacheControlValue = int.Parse(response.Headers["Cache-Control"].Split(',')[0].Split('=')[1]);
 								var cacheToTime = DateTime.Now + TimeSpan.FromSeconds(cacheControlValue);
 								cachedItem.ExpirationDate = cacheToTime;
 							}
 							else if(response.StatusCode == 200) // 200 OK, it means etag&data has changed so need to update cache
 							{
-								Debug.Log("200");
+								Debug.Log("200 - Updating cache");
 								string eTag = string.Empty;
 								DateTime expirationDate = DateTime.Now;
 								DateTime? lastModified = null;

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/SQLiteCache/SQLiteCache.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/SQLiteCache/SQLiteCache.cs
@@ -120,6 +120,7 @@ tile_column  BIGINT  NOT NULL,
 tile_row     BIGINT  NOT NULL,
 tile_data    BLOB    NOT NULL,
 timestamp    INTEGER NOT NULL,
+expirationdate    INTEGER NOT NULL,
 etag         TEXT,
 lastmodified INTEGER,
 	PRIMARY KEY(
@@ -248,6 +249,7 @@ lastmodified INTEGER,
 					tile_row = tileId.Y,
 					tile_data = item.Data,
 					timestamp = (int)UnixTimestampUtils.To(DateTime.Now),
+					expirationdate = (int)UnixTimestampUtils.To(item.ExpirationDate),
 					etag = item.ETag
 				});
 				if (1 != rowsAffected)

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/SQLiteCache/Tiles.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Cache/SQLiteCache/Tiles.cs
@@ -36,5 +36,8 @@ namespace Mapbox.Platform.Cache
 
 		/// <summary>Last-Modified header value of API response. Not all APIs populate it, will be -1 in that case. </summary>
 		public int? lastmodified { get; set; }
+
+		/// <summary>Last-Modified header value of API response. Not all APIs populate it, will be -1 in that case. </summary>
+		public int expirationdate { get; set; }
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/FileSource.cs
@@ -27,6 +27,7 @@ namespace Mapbox.Platform
 #endif
 #if UNITY_5_3_OR_NEWER
 	using UnityEngine;
+
 #endif
 
 	/// <summary>
@@ -40,7 +41,6 @@ namespace Mapbox.Platform
 	/// </remarks>
 	public sealed class FileSource : IFileSource
 	{
-
 		private Func<string> _getMapsSkuToken;
 		private readonly Dictionary<IAsyncRequest, int> _requests = new Dictionary<IAsyncRequest, int>();
 		private readonly string _accessToken;
@@ -49,8 +49,10 @@ namespace Mapbox.Platform
 		/// <summary>Length of rate-limiting interval in seconds. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 #pragma warning disable 0414
 		private int? XRateLimitInterval;
+
 		/// <summary>Maximum number of requests you may make in the current interval before reaching the limit. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		private long? XRateLimitLimit;
+
 		/// <summary>Timestamp of when the current interval will end and the ratelimit counter is reset. https://www.mapbox.com/api-documentation/#rate-limit-headers </summary>
 		private DateTime? XRateLimitReset;
 #pragma warning restore 0414
@@ -59,14 +61,7 @@ namespace Mapbox.Platform
 		public FileSource(Func<string> getMapsSkuToken, string acessToken = null)
 		{
 			_getMapsSkuToken = getMapsSkuToken;
-			if (string.IsNullOrEmpty(acessToken))
-			{
-				_accessToken = Environment.GetEnvironmentVariable("MAPBOX_ACCESS_TOKEN");
-			}
-			else
-			{
-				_accessToken = acessToken;
-			}
+			_accessToken = acessToken;
 		}
 
 		/// <summary> Performs a request asynchronously. </summary>
@@ -92,7 +87,8 @@ namespace Mapbox.Platform
 				string skuToken = "sku=" + _getMapsSkuToken();
 				if (uriBuilder.Query != null && uriBuilder.Query.Length > 1)
 				{
-					uriBuilder.Query = uriBuilder.Query.Substring(1) + "&" + accessTokenQuery + "&" + skuToken;;
+					uriBuilder.Query = uriBuilder.Query.Substring(1) + "&" + accessTokenQuery + "&" + skuToken;
+					;
 				}
 				else
 				{
@@ -127,16 +123,27 @@ namespace Mapbox.Platform
 			, string tilesetId
 		)
 		{
-
 			// TODO: plugin caching somewhere around here
 
 			var request = IAsyncRequestFactory.CreateRequest(
 				url
 				, (Response response) =>
 				{
-					if (response.XRateLimitInterval.HasValue) { XRateLimitInterval = response.XRateLimitInterval; }
-					if (response.XRateLimitLimit.HasValue) { XRateLimitLimit = response.XRateLimitLimit; }
-					if (response.XRateLimitReset.HasValue) { XRateLimitReset = response.XRateLimitReset; }
+					if (response.XRateLimitInterval.HasValue)
+					{
+						XRateLimitInterval = response.XRateLimitInterval;
+					}
+
+					if (response.XRateLimitLimit.HasValue)
+					{
+						XRateLimitLimit = response.XRateLimitLimit;
+					}
+
+					if (response.XRateLimitReset.HasValue)
+					{
+						XRateLimitReset = response.XRateLimitReset;
+					}
+
 					callback(response);
 					lock (_lock)
 					{
@@ -161,6 +168,7 @@ namespace Mapbox.Platform
 					_requests.Add(request, 0);
 				}
 			}
+
 			//yield return request;
 			return request;
 		}
@@ -193,11 +201,11 @@ namespace Mapbox.Platform
 						}
 					}
 				}
+
 				yield return new WaitForSeconds(0.2f);
 			}
 		}
 #endif
-
 
 
 #if !UNITY_5_3_OR_NEWER

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/IAsyncRequestFactory.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/IAsyncRequestFactory.cs
@@ -34,6 +34,22 @@ namespace Mapbox.Platform {
 #endif
 		}
 
-
+		public static IAsyncRequest CreateRequest(
+			string url
+			, int timeout
+			, string headerName
+			, string headerValue
+			, Action<Response> callback
+		) {
+#if !UNITY
+			if (Environment.ProcessorCount > 2) {
+				return new HTTPRequestThreaded(url, callback, timeout);
+			} else {
+				return new HTTPRequestNonThreaded(url, callback, timeout);
+			}
+#else
+			return new Mapbox.Unity.Utilities.HTTPRequest(url, callback, timeout, headerName, headerValue);
+#endif
+		}
 	}
 }

--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Response.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/Response.cs
@@ -315,7 +315,7 @@ namespace Mapbox.Platform
 			int statusCode = (int)apiResponse.responseCode;
 			response.StatusCode = statusCode;
 
-			if (statusCode != 200)
+			if (statusCode != 200 && statusCode != 304)
 			{
 				response.AddException(new Exception(string.Format("Status Code {0}", apiResponse.responseCode)));
 			}

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/HTTPRequest.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/HTTPRequest.cs
@@ -68,6 +68,25 @@ namespace Mapbox.Unity.Utilities
 			Runnable.Run(DoRequest());
 		}
 
+		public HTTPRequest(string url, Action<Response> callback, int timeout, string headerName, string headerValue)
+		{
+			IsCompleted = false;
+			_requestType = HttpRequestType.Get;
+			_request = UnityWebRequest.Get(url);
+			_request.SetRequestHeader(headerName, headerValue);
+
+			_request.timeout = timeout;
+			_callback = callback;
+
+#if UNITY_EDITOR
+			if (!EditorApplication.isPlaying)
+			{
+				Runnable.EnableRunnableInEditor();
+			}
+#endif
+			Runnable.Run(DoRequest());
+		}
+
 		public void Cancel()
 		{
 			if (_request != null)


### PR DESCRIPTION
fix a bug where tile cache expiration wasn't handled correct.
after the fix system will use `If-None-Match` header to check server for updates, this should half the server requests compared to old `header-only` request system.