### PR TITLE
Fix current version in readme

### DIFF
--- a/sdkproject/Assets/Mapbox/README.txt
+++ b/sdkproject/Assets/Mapbox/README.txt
@@ -11,7 +11,7 @@ API: https://www.mapbox.com/mapbox-unity-sdk/api/
 
 
 
-Current version: 2.0.1, as of December 21st, 2018
+Current version: 2.1.1, as of October 15th, 2019
 
 Changelog: https://www.mapbox.com/mapbox-unity-sdk/docs/05-changelog.html
 


### PR DESCRIPTION
**Related issue**
Closes #1742 

**Description of changes**
Simple change to update the version on MapBox/Readme. Confuses me when I import only the mapbox sdk (without AR and other third-party libs), and check the version in the readme.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**
@abhishektrip @brnkhy 