### PR TITLE
Fixed memory leak

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryEditor.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Telemetry/TelemetryEditor.cs
@@ -80,6 +80,8 @@ namespace Mapbox.Unity.Telemetry
 
 			postRequest.downloadHandler = new DownloadHandlerBuffer();
 			postRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+			
+			postRequest.uploadHandler.Dispose();
 
 			yield return postRequest.SendWebRequest();
 


### PR DESCRIPTION
**Unity Web Request UploadHandler** isn't disposed correctly, resulting memory leak. There is no code for signaling that the **UploadHandler** is no longer used and cleaning up the resources it is using. I am working on example scene **"ZoomableMap"** for my project. It happened with Unity 2021.1.5f1, Unity 2019.4.29f1 and mobile devices also, all results memory leak and crashes when start playing (90 % of times).

![mb](https://user-images.githubusercontent.com/63592766/130313667-a9c2edfc-959d-4881-95fd-ab88cf2fe5c7.png)


**Description of changes**

Added code to dispose **UploadHandler**

**Reviewers**

@abhishektrip @brnkhy 
