### PR TITLE
Fix broken add existing go modifier window

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 - Fixes a bug where add collider feature didn't work for flat terrain mesh.
 - Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+- Fix bug that caused ScriptableCreatorWindow to throw ArgumentException: GUILayout: Mismatched LayoutGroup.repaint in some environments.
 ### Improvements
 - Improves Directions factory and prefabs to provide better UX and support for all types of maps
 

--- a/sdkproject/Assets/Mapbox/Unity/Editor/ScriptableCreatorWindow.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Editor/ScriptableCreatorWindow.cs
@@ -20,6 +20,7 @@
 		int _index = -1;
 		private Action<UnityEngine.Object> _act;
 		int activeIndex = 0;
+		private List<Editor> assetEditors;
 
 		GUIStyle headerFoldout = new GUIStyle("Foldout");
 		GUIStyle header;
@@ -126,9 +127,7 @@
 					EditorGUILayout.Space();
 					EditorGUI.indentLevel += 4;
 					GUI.enabled = false;
-					var ed = UnityEditor.Editor.CreateEditor(asset);
-					ed.hideFlags = HideFlags.NotEditable;
-					ed.OnInspectorGUI();
+					DrawTheAsset(i);
 					GUI.enabled = true;
 					EditorGUI.indentLevel -= 4;
 					EditorGUILayout.Space();
@@ -187,6 +186,40 @@
 			}
 
 			return show;
+		}
+		
+		private void DrawTheAsset(int assetIndex)
+		{
+			if (assetEditors == null) assetEditors = new List<Editor>();
+
+			while (assetEditors.Count < _assets.Count)
+			{
+				assetEditors.Add(null);
+			}
+
+			while (assetEditors.Count > _assets.Count)
+			{
+				var index = assetEditors.Count - 1;
+				if (assetEditors[index] != null) DestroyImmediate(assetEditors[index]);
+				assetEditors.RemoveAt(index);
+			}
+
+			ScriptableObject asset = _assets[assetIndex];
+			Editor editor = assetEditors[assetIndex];
+
+			if (Event.current.type == EventType.Repaint && editor != null && editor.target != asset)
+			{
+				DestroyImmediate(editor);
+				editor = null;
+			}
+
+			if (editor == null)
+			{
+				editor = Editor.CreateEditor(asset);
+				assetEditors[assetIndex] = editor;
+			}
+
+			editor.OnInspectorGUI();
 		}
 	}
 }


### PR DESCRIPTION
**Related issue**

Example: 

![7AB8807F-2E67-4350-93F5-100EF31001AA](https://user-images.githubusercontent.com/2967721/133527565-2b1dd37a-909c-49e9-93ca-0e226f3276a4.GIF)

**Description of changes**

Draw gameobject modifier inspectors utilizing a list of `List<Editor>` in order to prevent `ArgumentException: GUILayout: Mismatched LayoutGroup.repaint
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.` error.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [x] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
