### PR TITLE
Fix SpawnOnMap objects not scaling on zoom

### DIFF
--- a/sdkproject/Assets/Mapbox/Examples/6_ZoomableMap/Scripts/SpawnOnMap.cs
+++ b/sdkproject/Assets/Mapbox/Examples/6_ZoomableMap/Scripts/SpawnOnMap.cs
@@ -36,6 +36,7 @@
 				var instance = Instantiate(_markerPrefab);
 				instance.transform.localPosition = _map.GeoToWorldPosition(_locations[i], true);
 				instance.transform.localScale = new Vector3(_spawnScale, _spawnScale, _spawnScale);
+				instance.transform.SetParent(_map.transform);
 				_spawnedObjects.Add(instance);
 			}
 		}
@@ -47,7 +48,7 @@
 			{
 				var spawnedObject = _spawnedObjects[i];
 				var location = _locations[i];
-				spawnedObject.transform.localPosition = _map.GeoToWorldPosition(location, true);
+				spawnedObject.transform.position = _map.GeoToWorldPosition(location, true);
 				spawnedObject.transform.localScale = new Vector3(_spawnScale, _spawnScale, _spawnScale);
 			}
 		}


### PR DESCRIPTION


**Related issue**

Fixes #1826

**Description of changes**

The current implementation never sets a parent, so the references to local position and scale in the `Update` function just refer to global position and rotation. This change sets the `AbstractMap _map` as the parent of the newly instantiated object and sets local scale according against that. For position we set global instead of local position because `GeoToWorldPosition` returns the global position.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
