### PR TITLE
Make QuadTreeTileProvider respect map's orientation in Unity Space

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
@@ -48,7 +48,11 @@ namespace Mapbox.Unity.Map.TileProviders
 				_cbtpOptions.camera = Camera.main;
 			}
 			_cbtpOptions.camera.transform.hasChanged = false;
-			_groundPlane = new Plane(Vector3.up, 0);
+			_groundPlane = new Plane(
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude, false),
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude + new Vector2d(0, 1), false),
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude + new Vector2d(1, 0), false)
+			);
 			_shouldUpdate = true;
 			_currentExtent.activeTiles = new HashSet<UnwrappedTileId>();
 		}


### PR DESCRIPTION
Right now the camera-bounded tile provider sets the ground plane as `new Plane(Vector3.up, 0)`, regardless of the actual orientation of the map object. This results in nothing rendering if the map GameObject has been rotated. This can be fixed by instead defining the plane by taking three arbitrary points on the map and finding their corresponding point in Unity space, and using these points to define the ground plane.