### PR TITLE
Use UniAndroid to check permission status

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Location/DeviceLocationProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Location/DeviceLocationProvider.cs
@@ -164,7 +164,7 @@ namespace Mapbox.Unity.Location
 			{
 				UniAndroidPermission.RequestPermission(AndroidPermission.ACCESS_FINE_LOCATION);
 				//wait for user to allow or deny
-				while (!_gotPermissionRequestResponse) { yield return _wait1sec; }
+				while (!UniAndroidPermission.IsPermitted(AndroidPermission.ACCESS_FINE_LOCATION)) { yield return _wait1sec; }
 			}
 #endif
 
@@ -316,9 +316,9 @@ namespace Mapbox.Unity.Location
 							// atan2 increases angle CCW, flip sign of latDiff to get CW
 							double latDiff = -(_lastPositions[i].x - _lastPositions[i - 1].x);
 							double lngDiff = _lastPositions[i].y - _lastPositions[i - 1].y;
-							// +90.0 to make top (north) 0°
+							// +90.0 to make top (north) 0Â°
 							double heading = (Math.Atan2(latDiff, lngDiff) * 180.0 / Math.PI) + 90.0f;
-							// stay within [0..360]° range
+							// stay within [0..360]Â° range
 							if (heading < 0) { heading += 360; }
 							if (heading >= 360) { heading -= 360; }
 							lastHeadings[i - 1] = (float)heading;
@@ -327,7 +327,7 @@ namespace Mapbox.Unity.Location
 						_userHeadingSmoothing.Add(lastHeadings[0]);
 						float finalHeading = (float)_userHeadingSmoothing.Calculate();
 
-						//fix heading to have 0° for north, 90° for east, 180° for south and 270° for west
+						//fix heading to have 0Â° for north, 90Â° for east, 180Â° for south and 270Â° for west
 						finalHeading = finalHeading >= 180.0f ? finalHeading - 180.0f : finalHeading + 180.0f;
 
 


### PR DESCRIPTION
In the existing implementation, `_gotPermissionRequestResponse` is not reliably set when the user sets permission, which can leave the application in a broken state that can only be resolved by force-quitting and restarting. Using UniAndroid instead seems to fix the issue and results in the application being in a working state after the user accepts the permission request.

**Related issue**

Example: Closes #832. Relates to #832.

**Description of changes**

Your text here!

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
