### PR TITLE
Bugfix/point in polygon

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 - Fixes a bug where add collider feature didn't work for flat terrain mesh.
 - Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+- Fixed incorrect computation of PointInPolygon when point was near center of polygon
 ### Improvements
 - Improves Directions factory and prefabs to provide better UX and support for all types of maps
 

--- a/sdkproject/Assets/Mapbox/Unity/Utilities/PolygonUtils.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Utilities/PolygonUtils.cs
@@ -17,54 +17,21 @@ namespace Mapbox.Utils
 		/// <param name="p">The point that is to be tested.</param>
 		public static bool PointInPolygon(Point2d<float> p, List<List<Point2d<float>>> polygon)
 		{
-			List<Point2d<float>> poly = polygon[0];
-
-			Point2d<float> p1;
-			Point2d<float> p2;
 			bool inside = false;
-
-			if (poly.Count < 3)
-			{
-				return inside;
-			}
-
-			var oldPoint = new Point2d<float>(
-				poly[poly.Count - 1].X
-				, poly[poly.Count - 1].Y
-			);
-
+			int j = poly.Count - 1;
 			for (int i = 0; i < poly.Count; i++)
 			{
-				var newPoint = new Point2d<float>(poly[i].X, poly[i].Y);
-
-				if (newPoint.X > oldPoint.X)
+				if (poly[i].Y < p.Y && poly[j].Y >= p.Y || poly[j].Y < p.Y && poly[i].Y >= p.Y)
 				{
-					p1 = oldPoint;
-					p2 = newPoint;
+					if (poly[i].X + (p.Y - poly[i].Y) / (poly[j].Y - poly[i].Y) * (poly[j].X - poly[i].X) < p.X)
+					{
+						inside = !inside;
+					}
 				}
-				else
-				{
-					p1 = newPoint;
-					p2 = oldPoint;
-				}
-
-				if (
-					(newPoint.X < p.X) == (p.X <= oldPoint.X)
-					&& (p.Y - (long)p1.Y) * (p2.X - p1.X) < (p2.Y - (long)p1.Y) * (p.X - p1.X)
-				)
-				{
-					inside = !inside;
-				}
-
-				oldPoint = newPoint;
+				j = i;
 			}
 
 			return inside;
 		}
-
-
-
 	}
-
 }
-


### PR DESCRIPTION
**Related issue**
https://github.com/mapbox/mapbox-unity-sdk/issues/1893


**Description of changes**
The current algorithm is based on https://stackoverflow.com/a/7123291
However, that algorithm fails when checking a point near the center of the polygon.

Just below that answer is https://stackoverflow.com/a/14998816

While I don't love that it still takes a list of lists, I have not changed that in order to maintain backwards-compatibility (see: https://github.com/mapbox/mapbox-unity-sdk/issues/1873)

I'm not sure where tests would be added - I don't see any existing tests. Happy to add what's listed in the issue as a regression test if you can point me to where that'd be appropriate.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Not sure who to tag.