### PR TITLE
bugfix _map.SetCenterLatitudeLongitude and _map.UpdateMap() with CultureInfo

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/AbstractMap.cs
@@ -1127,7 +1127,7 @@ namespace Mapbox.Unity.Map
 
 		public virtual void SetCenterLatitudeLongitude(Vector2d centerLatitudeLongitude)
 		{
-			_options.locationOptions.latitudeLongitude = string.Format("{0}, {1}", centerLatitudeLongitude.x.ToString(CultureInfo.InvariantCulture), centerLatitudeLongitude.y.ToString(CultureInfo.InvariantCulture));
+			_options.locationOptions.latitudeLongitude = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", centerLatitudeLongitude.x.ToString(CultureInfo.InvariantCulture), centerLatitudeLongitude.y.ToString(CultureInfo.InvariantCulture));
 			_centerLatitudeLongitude = centerLatitudeLongitude;
 		}
 


### PR DESCRIPTION
When using _map.SetCenterLatitudeLongitude(), this function saves the current latitude and longitude as string. It uses stringFormat to cast Vector2d x and y to string, but doesn't use InvariantCulture like it does at line 319, inside Initialize().
Decimal separator depends on the culture but InvariantCulture uses . which is what you want. In some cases , is used.
The problem is that it was saving Vector2d(1.2, 3.4) as "1,2, 3,4" instead of "1.2, 3.4. This raises an error when using _map.UpdateMap(), when using Conversion.StringToLatLon(). A split is made with "," as separator, raising an ArgumentException("Wrong number of arguments") because the number of arguments are 4 instead of 2.

