### PR TITLE
Prevent NPE when TileData is null

### DIFF
--- a/Runtime/Mapbox/VectorModule/VectorLayerModule.cs
+++ b/Runtime/Mapbox/VectorModule/VectorLayerModule.cs
@@ -140,6 +140,11 @@ namespace Mapbox.VectorModule
 		{
 			VectorData tileData = null;
 			yield return _vectorSource.LoadTileCoroutine(tile, data => tileData = data);
+			if (tileData == null)
+			{
+				Debug.LogWarning("Loaded tile data is null");
+				yield break;
+			}
 			yield return CreateVisualCoroutine(tile, tileData);
 		}
 		


### PR DESCRIPTION
**Related issue**

N/A

**Description of changes**

LoadTileCoroutine is not guaranteed to produce non-null tileData. Handle that.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
