### PR TITLE
Fix geocoding by fixing JSON serialization after il2cpp

### DIFF
--- a/Runtime/Mapbox/GeocodingApi/Response/Feature.cs
+++ b/Runtime/Mapbox/GeocodingApi/Response/Feature.cs
@@ -23,42 +23,42 @@ namespace Mapbox.GeocodingApi
 		/// <summary> Gets or sets the id. Ids are unique in the Mapbox geocoder. </summary>
 		/// <value>The id.</value>
 		[JsonProperty("id")]
-		public string Id { get; set; }
+		public string Id;
 
 		/// <summary> 
 		///     Gets or sets feature type. One of country,  region,  postcode,  place,  locality, neighborhood,  address,  poi.
 		/// </summary>
 		/// <value>The type.</value>
 		[JsonProperty("type")]
-		public string Type { get; set; }
+		public string Type;
 
 		/// <summary>
 		/// Gets or sets the text.
 		/// </summary>
 		/// <value>The text.</value>
 		[JsonProperty("text")]
-		public string Text { get; set; }
+		public string Text;
 
 		/// <summary>
 		/// Gets or sets the name of the place.
 		/// </summary>
 		/// <value>The name of the place.</value>
 		[JsonProperty("place_name")]
-		public string PlaceName { get; set; }
+		public string PlaceName;
 
 		/// <summary>
 		/// Gets or sets the relevance.
 		/// </summary>
 		/// <value>The relevance.</value>
 		[JsonProperty("relevance")]
-		public double Relevance { get; set; }
+		public double Relevance;
 
 		/// <summary>
 		/// Gets or sets the properties.
 		/// </summary>
 		/// <value>The properties.</value>
 		[JsonProperty("properties")]
-		public Dictionary<string, object> Properties { get; set; }
+		public Dictionary<string, object> Properties;
 
 		/// <summary>
 		/// Gets or sets the bbox.
@@ -66,7 +66,7 @@ namespace Mapbox.GeocodingApi
 		/// <value>The bbox.</value>
 		[JsonProperty("bbox", NullValueHandling = NullValueHandling.Ignore)]
 		[JsonConverter(typeof(BboxToVector2dBoundsConverter))]
-		public LatitudeLongitudeBounds? Bbox { get; set; }
+		public LatitudeLongitudeBounds? Bbox;
 
 		/// <summary>
 		/// Gets or sets the center.
@@ -74,26 +74,26 @@ namespace Mapbox.GeocodingApi
 		/// <value>The center.</value>
 		[JsonProperty("center")]
 		[JsonConverter(typeof(LonLatToVector2dConverter))]
-		public Vector2d Center { get; set; }
+		public Vector2d Center;
 
 		/// <summary>
 		/// Gets or sets the geometry.
 		/// </summary>
 		/// <value>The geometry.</value>
 		[JsonProperty("geometry")]
-		public Geometry Geometry { get; set; }
+		public Geometry Geometry;
 
 		/// <summary>
 		/// Gets or sets the address.
 		/// </summary>
 		[JsonProperty("address", NullValueHandling = NullValueHandling.Ignore)]
-		public string Address { get; set; }
+		public string Address;
 
 		/// <summary>
 		/// Gets or sets the context.
 		/// </summary>
 		/// <value>The context.</value>
 		[JsonProperty("context", NullValueHandling = NullValueHandling.Ignore)]
-		public List<Dictionary<string, string>> Context { get; set; }
+		public List<Dictionary<string, string>> Context;
 	}
 }

--- a/Runtime/Mapbox/GeocodingApi/Response/GeocodeResponse.cs
+++ b/Runtime/Mapbox/GeocodingApi/Response/GeocodeResponse.cs
@@ -16,27 +16,28 @@ namespace Mapbox.GeocodingApi
 	//http://stackoverflow.com/a/12903628
 	[Serializable]
 #endif
-	public abstract class GeocodeResponse {
+	public abstract class GeocodeResponse
+	{
 		/// <summary>
 		/// Gets or sets the type.
 		/// </summary>
 		/// <value>The type.</value>
 		[JsonProperty("type", Order = 0)]
-		public string Type { get; set; }
+		public string Type;
 
 		/// <summary>
 		/// Gets or sets the features.
 		/// </summary>
 		/// <value>The features.</value>
 		[JsonProperty("features", Order = 2)]
-		public List<Feature> Features { get; set; }
+		public List<Feature> Features;
 
 		/// <summary>
 		/// Gets or sets the attribution.
 		/// </summary>
 		/// <value>The attribution.</value>
 		[JsonProperty("attribution", Order = 3)]
-		public string Attribution { get; set; }
+		public string Attribution;
 	}
 
 	/// <summary>
@@ -46,13 +47,14 @@ namespace Mapbox.GeocodingApi
 	//http://stackoverflow.com/a/12903628
 	[Serializable]
 #endif
-	public class ReverseGeocodeResponse : GeocodeResponse {
+	public class ReverseGeocodeResponse : GeocodeResponse
+	{
 		/// <summary>
 		/// Gets or sets the query.
 		/// </summary>
 		/// <value>The query.</value>
 		[JsonProperty("query", Order = 1)]
-		public List<double> Query { get; set; }
+		public List<double> Query;
 	}
 
 	/// <summary>
@@ -62,12 +64,13 @@ namespace Mapbox.GeocodingApi
 	//http://stackoverflow.com/a/12903628
 	[Serializable]
 #endif
-	public class ForwardGeocodeResponse : GeocodeResponse {
+	public class ForwardGeocodeResponse : GeocodeResponse
+	{
 		/// <summary>
 		/// Gets or sets the query.
 		/// </summary>
 		/// <value>The query.</value>
 		[JsonProperty("query", Order = 1)]
-		public List<string> Query { get; set; }
+		public List<string> Query;
 	}
 }

--- a/Runtime/Mapbox/GeocodingApi/Response/Geometry.cs
+++ b/Runtime/Mapbox/GeocodingApi/Response/Geometry.cs
@@ -23,7 +23,7 @@ namespace Mapbox.GeocodingApi
 		/// </summary>
 		/// <value>The GeoJSON geometry type.</value>
 		[JsonProperty("type")]
-		public string Type { get; set; }
+		public string Type;
 
 		/// <summary>
 		///     Gets or sets coordinates. Because they are points, Geocode results will always be  a single Geocoordinate.
@@ -31,6 +31,6 @@ namespace Mapbox.GeocodingApi
 		/// <value>The coordinates.</value>
 		[JsonConverter(typeof(LonLatToVector2dConverter))]
 		[JsonProperty("coordinates")]
-		public Vector2d Coordinates { get; set; }
+		public Vector2d Coordinates;
 	}
 }


### PR DESCRIPTION
**Related issue**

Reverse geocoding doesn't work for iOS and Android. I believe this is due to il2cpp. I believe this is due to JsonUtility's limitations (e.g. see https://discussions.unity.com/t/unitys-jsonutility-does-not-work-on-public-accessors/722755).

**Description of changes**

Remove accessors. Replace with public variables.

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
