### PR TITLE
Fix mesh bounds on terrain tiles

### DIFF
--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
@@ -43,6 +43,44 @@ namespace Mapbox.BaseModule.Unity
             TerrainData.ElevationValuesUpdated += OnElevationValuesUpdated;
 
             _unityMapTile.Material.SetFloat(_elevationMultiplierFieldNameID, useShaderElevation ? 1 : 0);
+            FixMeshBounds(useShaderElevation);
+        }
+
+        private void FixMeshBounds(bool useShaderElevation)
+        {
+            Mesh mesh = _unityMapTile.MeshFilter.mesh;
+            if (mesh == null)
+            {
+                return;
+            }
+
+            float elevation = useShaderElevation ? GetMaxExtent() : 0f;
+            Vector3 newExtents = mesh.bounds.extents;
+            newExtents.y = elevation;
+            mesh.bounds = new Bounds(mesh.bounds.center, newExtents);
+        }
+
+        private float GetMaxExtent()
+        {
+            if (TerrainData == null || TerrainData.ElevationValues == null)
+            {
+                return 0;
+            }
+
+            float max = 0;
+            float min = float.MaxValue;
+            for (int i = 0; i < TerrainData.ElevationValues.Length; i++)
+            {
+                if (TerrainData.ElevationValues[i] > max)
+                {
+                    max = TerrainData.ElevationValues[i];
+                }
+                if (TerrainData.ElevationValues[i] < min)
+                {
+                    min = TerrainData.ElevationValues[i];
+                }
+            }
+            return Mathf.Max(Mathf.Abs(min), max);
         }
 
         public void OnTerrainUpdated()

--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
@@ -10,7 +10,7 @@ namespace Mapbox.BaseModule.Unity
     public class UnityTileTerrainContainer
     {
         public TileContainerState State = TileContainerState.Final;
-        public static Action<UnityTileTerrainContainer> ElevationValuesUpdated = (t) => { };
+        public Action<UnityMapTile> ElevationValuesUpdated = (t) => { };
         
         private string _elevationMultiplierFieldNameID = "_ElevationMultiplier";
         private string _elevationChangeTimerFieldNameID = "_ElevationChangeTime";
@@ -106,7 +106,7 @@ namespace Mapbox.BaseModule.Unity
                 return;
             }
             TerrainData.IsElevationDataReady = true;
-            ElevationValuesUpdated(this);
+            ElevationValuesUpdated(_unityMapTile);
         }
 
         public TerrainData GetAndClearTerrainData()

--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
@@ -10,7 +10,7 @@ namespace Mapbox.BaseModule.Unity
     public class UnityTileTerrainContainer
     {
         public TileContainerState State = TileContainerState.Final;
-        public Action<UnityMapTile> ElevationValuesUpdated = (t) => { };
+        public static Action<UnityTileTerrainContainer> ElevationValuesUpdated = (t) => { };
         
         private string _elevationMultiplierFieldNameID = "_ElevationMultiplier";
         private string _elevationChangeTimerFieldNameID = "_ElevationChangeTime";
@@ -106,7 +106,7 @@ namespace Mapbox.BaseModule.Unity
                 return;
             }
             TerrainData.IsElevationDataReady = true;
-            ElevationValuesUpdated(_unityMapTile);
+            ElevationValuesUpdated(this);
         }
 
         public TerrainData GetAndClearTerrainData()

--- a/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
+++ b/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
@@ -219,6 +219,7 @@ namespace Mapbox.VectorModule
                     if(!_results.ContainsKey(canonicalTileId))
                         _results.Add(canonicalTileId, new List<VectorEntity>());
                     _results[canonicalTileId].Add(entity);
+                    entity.Mesh.RecalculateBounds();
                     OnVectorMeshCreated(entity.GameObject);
                 }
             }


### PR DESCRIPTION
Without this change, oblique camera angles would assume the entire tile is out of the viewport and not render since the mesh extent's height is 0, and the tile plane is out of the viewport but, with elevation, it is in bounds.