### PR TITLE
Update UnityTile.cs to support unity 6.2

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -245,7 +245,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 				// HACK: compute height values for terrain. We could probably do this without a texture2d.
 				if (_heightTexture == null)
 				{
-					_heightTexture = new Texture2D(0, 0);
+					_heightTexture = new Texture2D(1, 1);
 				}
 
 				_heightTexture.LoadImage(data);
@@ -292,7 +292,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 
 				if (_rasterData == null)
 				{
-					_rasterData = new Texture2D(0, 0, TextureFormat.RGB24, useMipMap);
+					_rasterData = new Texture2D(1, 1, TextureFormat.RGB24, useMipMap);
 					_rasterData.wrapMode = TextureWrapMode.Clamp;
 				}
 


### PR DESCRIPTION
Unity 6.2 fix for error: Texture must have width greater than 0

**Related issue**

Example: Closes #832. Relates to #832.

**Description of changes**

Your text here!

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
