### PR TITLE
 Qol Changes to LatitudeLongitude.

### DIFF
--- a/Runtime/Mapbox/BaseModule/Data/Vector2d/Vector2d.cs
+++ b/Runtime/Mapbox/BaseModule/Data/Vector2d/Vector2d.cs
@@ -272,31 +272,61 @@ namespace Mapbox.BaseModule.Data.Vector2d
 		public double Latitude;
 		public double Longitude;
 
-		public LatitudeLongitude(double latitude, double longitude)
-		{
-			Latitude = latitude;
-			Longitude = longitude;
-		}
-		
-		public override string ToString()
-		{
-			return string.Format(NumberFormatInfo.InvariantInfo, "{0},{1}", this.Latitude, this.Longitude);
-		}
-		
-		public string ToStringLonLat()
-		{
-			return string.Format(NumberFormatInfo.InvariantInfo, "{0:F5},{1:F5}", this.Longitude, this.Latitude);
-		}
+        public const double MAX_LATITUDE = 90;
+        public const double MAX_LONGITUDE = 90;
 
-		public static double Dot(LatitudeLongitude lhs, LatitudeLongitude rhs)
-		{
-			return lhs.Latitude * rhs.Latitude + lhs.Longitude * rhs.Longitude;
-		}
-		
-		public static LatitudeLongitude operator -(LatitudeLongitude a, LatitudeLongitude b)
-		{
-			return new LatitudeLongitude(a.Longitude - b.Longitude, a.Latitude - b.Latitude);
-		}
+        public LatitudeLongitude(double latitude, double longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+        }
 
+        public static LatitudeLongitude Invalid => new(MAX_LATITUDE * 2, MAX_LONGITUDE * 2);
+
+        public override string ToString()
+        {
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0},{1}", this.Latitude, this.Longitude);
+        }
+
+        public string ToStringLonLat()
+        {
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0:F5},{1:F5}", this.Longitude, this.Latitude);
+        }
+
+        public static double Dot(LatitudeLongitude lhs, LatitudeLongitude rhs)
+        {
+            return lhs.Latitude * rhs.Latitude + lhs.Longitude * rhs.Longitude;
+        }
+
+        public static LatitudeLongitude operator -(LatitudeLongitude a, LatitudeLongitude b)
+        {
+            return new LatitudeLongitude(a.Longitude - b.Longitude, a.Latitude - b.Latitude);
+        }
+
+        public static bool AlmostEqual(double a, double b, double tolerance = double.Epsilon)
+        {
+            return Math.Abs(a - b) < tolerance;
+        }
+
+        public readonly bool Equals(in LatitudeLongitude other)
+        {
+            return AlmostEqual(this.Latitude, other.Latitude) && AlmostEqual(this.Longitude, other.Longitude);
+        }
+
+        public override bool Equals(object obj) => obj is LatitudeLongitude other && Equals(in other);
+        public static bool operator ==(in LatitudeLongitude a, in LatitudeLongitude b) => a.Equals(in b);
+        public static bool operator !=(in LatitudeLongitude a, in LatitudeLongitude b) => !a.Equals(in b);
+
+        public bool IsValid()// technically invalid only if latitude is outside of [-90, 90] as longitude can wrap around
+        {
+            return Latitude >= -MAX_LATITUDE &&
+                   Latitude <= MAX_LATITUDE &&
+                   Longitude >= -MAX_LONGITUDE &&
+                   Longitude <= MAX_LONGITUDE;
+        }
+        public override int GetHashCode()
+        {
+	        return this.x.GetHashCode() ^ this.y.GetHashCode() << 2;
+        }
 	}
 }


### PR DESCRIPTION
**Related issue**

- Can't compare LatitudeLongitude with each other using operators, 
- No easy way to validate LatitudeLongitude, 
- No easy way to create an invalid LatitudeLongitude

**Description of changes**

- Added equal and unequal operators to LatitudeLongitude
- Added IsValid function to LatitudeLongitude
- Added a static property for Invalid coordinates
- Added GetHashCode function override, same as in Vector2d

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
