### PR TITLE
Implemented VectorLayerModule callbacks

### DIFF
--- a/Runtime/Mapbox/VectorModule/VectorLayerModule.cs
+++ b/Runtime/Mapbox/VectorModule/VectorLayerModule.cs
@@ -25,6 +25,7 @@ namespace Mapbox.VectorModule
 		private HashSet<CanonicalTileId> _retainedTiles;
 		private HashSet<CanonicalTileId> _activeTiles;
 		private HashSet<CanonicalTileId> _readyTiles;
+		private HashSet<CanonicalTileId> _visibleTiles;
 		
 		public VectorLayerModule(IMapInformation mapInformation, Source<VectorData> source, MeshGenerationUnit meshGenerator, VectorModuleSettings vectorModuleSettings = null) : base()
 		{
@@ -36,6 +37,7 @@ namespace Mapbox.VectorModule
 			_vectorSource.CacheItemDisposed += ClearDisposedDataVisual;
 			_retainedTiles = new HashSet<CanonicalTileId>();
 			_activeTiles = new HashSet<CanonicalTileId>();
+			_visibleTiles = new HashSet<CanonicalTileId>();
 		}
 
 		public virtual IEnumerator Initialize()
@@ -79,12 +81,28 @@ namespace Mapbox.VectorModule
 			
 			foreach (var tileId in _readyTiles)
 			{
-				_meshGenerationUnit.SetVisualActive(tileId, _activeTiles.Contains(tileId) || _retainedTiles.Contains(tileId), _mapInformation);
+				var isRetained = _activeTiles.Contains(tileId) || _retainedTiles.Contains(tileId);
+				UpdateVisibilityCallbacks(tileId,isRetained);
+				_meshGenerationUnit.SetVisualActive(tileId, isRetained, _mapInformation);
 			}
 
 			_meshGenerationUnit.RetainTiles(_retainedTiles);
 			var isReady = _vectorSource.RetainTiles(_retainedTiles);
 			return isReady;
+		}
+		private void UpdateVisibilityCallbacks(CanonicalTileId tileId, bool isRetained)
+		{
+			if (isRetained && !_visibleTiles.Contains(tileId))
+			{
+				OnVectorMeshTurnVisible(tileId);
+				_visibleTiles.Add(tileId);
+				return;
+			}
+			if (!isRetained &&_visibleTiles.Contains(tileId))
+			{
+				OnVectorMeshTurnInvisible(tileId);
+				_visibleTiles.Remove(tileId);
+			}
 		}
 
 		private void UpdateActiveTileList(Dictionary<UnwrappedTileId, UnityMapTile> activeTiles)
@@ -265,28 +283,35 @@ namespace Mapbox.VectorModule
 			{
 				_meshGenerationUnit.MeshGeneration(vectorData, (result =>
 				{
-					if (result != null && result.ResultType == TaskResultType.Success)
+					if (result != null)
 					{
-						_readyTiles.Add(tileId);
-						OnVectorMeshCreated(result.GeneratedObjects);
-						_meshGenerationUnit.UpdateForView(tileId, _mapInformation);
-					}
-					else if (result.ResultType == TaskResultType.DataProcessingFailure)
-					{
-						_vectorSource.InvalidateData(vectorData.TileId);
-						Debug.Log(result.ExceptionsAsString);
-					}
-					else if (result.ResultType == TaskResultType.Cancelled)
-					{
-						if (result.GeneratedObjects != null)
+						switch (result.ResultType)
 						{
-							foreach (var gameObject in result.GeneratedObjects)
+							case TaskResultType.Success:
+								_readyTiles.Add(tileId);
+								_meshGenerationUnit.UpdateForView(tileId, _mapInformation);
+								UpdateVisibilityCallbacks(tileId, true);
+								OnVectorMeshCreated(vectorData.TileId, result.GeneratedObjects);
+								break;
+							case TaskResultType.DataProcessingFailure:
+								_vectorSource.InvalidateData(vectorData.TileId);
+								Debug.Log(result.ExceptionsAsString);
+								break;
+							case TaskResultType.Cancelled:
 							{
-								GameObject.Destroy(gameObject);
+								if (result.GeneratedObjects != null)
+								{
+									foreach (var gameObject in result.GeneratedObjects)
+									{
+										GameObject.Destroy(gameObject);
+									}
+								}
+
+								break;
 							}
 						}
 					}
-					callback?.Invoke(result);;
+					callback?.Invoke(result);
 				}));
 			}
 		}
@@ -309,12 +334,12 @@ namespace Mapbox.VectorModule
 		{
 			_readyTiles.Remove(tileId);
 			_meshGenerationUnit.ClearDisposedDataVisual(tileId);
-
+			OnVectorMeshDestroyed(tileId);
 		}
 
-		public Action<IEnumerable<GameObject>> OnVectorMeshCreated = list => { };
-		public Action<GameObject> OnVectorMeshDestroyed = go => { };
-		public Action<GameObject> OnVectorMeshTurnVisible = go => { };
-		public Action<GameObject> OnVectorMeshTurnInvisible = go => { };
+		public Action<CanonicalTileId, IEnumerable<GameObject>> OnVectorMeshCreated = (_, _) => {};
+		public Action<CanonicalTileId> OnVectorMeshDestroyed = _ => {};
+		public Action<CanonicalTileId> OnVectorMeshTurnVisible = _ => {};
+		public Action<CanonicalTileId> OnVectorMeshTurnInvisible = _ => {};
 	}
 }


### PR DESCRIPTION
**Related issue**

VectorLayerModule declares 4 callbacks (OnVectorMeshCreated, OnVectorMeshDestroyed, OnVectorMeshTurnVisible, OnVectorMeshTurnInvisible) but implements only 1 (OnVectorMeshCreated)

**Description of changes**

- Modified callbacks return values to include CanonicalTileId as a parameter, as a common tile identifier
- In the CreateVisual method in _meshGenerationUnit.MeshGeneration callback replaced if-else with switch for ease of reading
- Added _visibleTiles hashset to track visible tiles for  OnVectorMeshTurnVisible and OnVectorMeshTurnInvisible callbacks(could be done without it with a bit bigger rewrite of UpdateActiveTileList)
- UpdateVisibilityCallbacks, which triggers OnVectorMeshTurnVisible and OnVectorMeshTurnInvisible callbacks when the tile status change
- OnVectorMeshDestroyed callback call added to ClearDisposedDataVisual (seems like a logical place for it, but needs validation)

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
