### PR TITLE
Remove unnecessary delegates, combine/remove from UnityTileImageConta…

### DIFF
--- a/Runtime/Mapbox/BaseModule/Data/DataFetchers/MapboxTileData.cs
+++ b/Runtime/Mapbox/BaseModule/Data/DataFetchers/MapboxTileData.cs
@@ -13,12 +13,17 @@ namespace Mapbox.BaseModule.Data.DataFetchers
         public DateTime? ExpirationDate;
         public bool HasError = false;
         [HideInInspector] public byte[] Data;
+        
+        private Action _onDispose;
 
         public virtual void Dispose()
         {
-            OnDispose?.Invoke();
+            _onDispose?.Invoke();
         }
 
-        public Action OnDispose;
+        internal void SetDisposeCallback(Action callback)
+        {
+            _onDispose = callback;
+        }
     }
 }

--- a/Runtime/Mapbox/BaseModule/Data/DataFetchers/MapboxTileData.cs
+++ b/Runtime/Mapbox/BaseModule/Data/DataFetchers/MapboxTileData.cs
@@ -16,9 +16,9 @@ namespace Mapbox.BaseModule.Data.DataFetchers
 
         public virtual void Dispose()
         {
-            OnDispose();
+            OnDispose?.Invoke();
         }
-        
-        public Action OnDispose = () => { };
+
+        public Action OnDispose;
     }
 }

--- a/Runtime/Mapbox/BaseModule/Unity/UnityMapTile.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityMapTile.cs
@@ -61,10 +61,7 @@ namespace Mapbox.BaseModule.Unity
 
 		public void Awake()
 		{
-			ImageContainer = new UnityTileImageContainer(this)
-			{
-				OnDispose = DataDisposed
-			};
+			ImageContainer = new UnityTileImageContainer(this, DataDisposed);
 			VectorContainer = new UnityTileVectorContainer(this);
 			TerrainContainer = new UnityTileTerrainContainer(this);
 			TerrainContainer.ElevationValuesUpdated += tile =>

--- a/Runtime/Mapbox/BaseModule/Unity/UnityMapTile.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityMapTile.cs
@@ -61,8 +61,10 @@ namespace Mapbox.BaseModule.Unity
 
 		public void Awake()
 		{
-			ImageContainer = new UnityTileImageContainer(this);
-			ImageContainer.OnDispose += DataDisposed;
+			ImageContainer = new UnityTileImageContainer(this)
+			{
+				OnDispose = DataDisposed
+			};
 			VectorContainer = new UnityTileVectorContainer(this);
 			TerrainContainer = new UnityTileTerrainContainer(this);
 			TerrainContainer.ElevationValuesUpdated += tile =>

--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileImageContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileImageContainer.cs
@@ -8,30 +8,38 @@ namespace Mapbox.BaseModule.Unity
     [Serializable]
     public class UnityTileImageContainer
     {
-        public Action OnDispose;
-        public TileContainerState State = TileContainerState.Final;
+        public TileContainerState State { get; private set; } = TileContainerState.Final;
+        [field: SerializeField] public RasterData ImageData { get; private set; }
+        
+        private Action _onDispose;
         private UnityMapTile _unityMapTile;
-        private string _mainTexFieldNameID = "_MainTex";
-        private string _mainTexStFieldNameID = "_MainTex_ST";
-        private string _mainTextureChangeTimeFieldNameID = "_MainTextureChangeTime";
-        [SerializeField] public RasterData ImageData;
 
-        public UnityTileImageContainer(UnityMapTile unityMapTile)
+        private const string MainTexFieldNameID = "_MainTex";
+        private const string MainTexStFieldNameID = "_MainTex_ST";
+        private const string MainTextureChangeTimeFieldNameID = "_MainTextureChangeTime";
+        
+        private static readonly int MainTex = Shader.PropertyToID(MainTexFieldNameID);
+        private static readonly int MainTexSt = Shader.PropertyToID(MainTexStFieldNameID);
+        private static readonly int MainTextureChangeTime = Shader.PropertyToID(MainTextureChangeTimeFieldNameID);
+
+        public UnityTileImageContainer(UnityMapTile unityMapTile, Action onDispose)
         {
             _unityMapTile = unityMapTile;
+            _onDispose = onDispose;
         }
 
         public void SetImageData(RasterData imageData, TileContainerState state = TileContainerState.Final)
         {
-            if(ImageData != null) ImageData.OnDispose = null;
-            
+            ImageData?.SetDisposeCallback(null);
+
             State = state;
             if (imageData.Texture == null || imageData.TileId.Z == 0)
             {
                 Debug.Log("no texture?");
             }
+
             ImageData = imageData;
-            ImageData.OnDispose = OnDispose;
+            ImageData.SetDisposeCallback(_onDispose);
             OnImageryUpdated();
         }
 
@@ -39,12 +47,12 @@ namespace Mapbox.BaseModule.Unity
         {
             if (ImageData == null)
                 return;
-        
+
             var scaleOffset = _unityMapTile.CanonicalTileId.CalculateScaleOffsetAtZoom(ImageData.TileId.Z);
-            
-            _unityMapTile.Material.SetTexture(_mainTexFieldNameID, ImageData.Texture);
-            _unityMapTile.Material.SetVector(_mainTexStFieldNameID, scaleOffset);
-            _unityMapTile.Material.SetFloat(_mainTextureChangeTimeFieldNameID, Time.time);
+
+            _unityMapTile.Material.SetTexture(MainTex, ImageData.Texture);
+            _unityMapTile.Material.SetVector(MainTexSt, scaleOffset);
+            _unityMapTile.Material.SetFloat(MainTextureChangeTime, Time.time);
         }
 
         public RasterData GetAndClearImageData()
@@ -52,9 +60,9 @@ namespace Mapbox.BaseModule.Unity
             if (ImageData == null)
                 return null;
 
-            _unityMapTile.Material.SetTexture(_mainTexFieldNameID, Texture2D.blackTexture);
+            _unityMapTile.Material.SetTexture(MainTex, Texture2D.blackTexture);
             var rd = ImageData;
-            ImageData.OnDispose = null;
+            ImageData.SetDisposeCallback(null);
             ImageData = null;
             return rd;
         }
@@ -62,9 +70,9 @@ namespace Mapbox.BaseModule.Unity
         public void DisableImagery()
         {
             State = TileContainerState.Final;
-            _unityMapTile.Material.SetTexture(_mainTexFieldNameID, null);
+            _unityMapTile.Material.SetTexture(MainTex, null);
         }
-        
+
         public void OnDestroy()
         {
             //anything to finalize here?

--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileImageContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileImageContainer.cs
@@ -8,7 +8,7 @@ namespace Mapbox.BaseModule.Unity
     [Serializable]
     public class UnityTileImageContainer
     {
-        public Action OnDispose = () => { };
+        public Action OnDispose;
         public TileContainerState State = TileContainerState.Final;
         private UnityMapTile _unityMapTile;
         private string _mainTexFieldNameID = "_MainTex";
@@ -23,7 +23,7 @@ namespace Mapbox.BaseModule.Unity
 
         public void SetImageData(RasterData imageData, TileContainerState state = TileContainerState.Final)
         {
-            if(ImageData != null) ImageData.OnDispose -= OnDispose;
+            if(ImageData != null) ImageData.OnDispose = null;
             
             State = state;
             if (imageData.Texture == null || imageData.TileId.Z == 0)
@@ -31,7 +31,7 @@ namespace Mapbox.BaseModule.Unity
                 Debug.Log("no texture?");
             }
             ImageData = imageData;
-            ImageData.OnDispose += OnDispose;
+            ImageData.OnDispose = OnDispose;
             OnImageryUpdated();
         }
 
@@ -54,7 +54,7 @@ namespace Mapbox.BaseModule.Unity
 
             _unityMapTile.Material.SetTexture(_mainTexFieldNameID, Texture2D.blackTexture);
             var rd = ImageData;
-            ImageData.OnDispose -= OnDispose;
+            ImageData.OnDispose = null;
             ImageData = null;
             return rd;
         }


### PR DESCRIPTION
…iner

**Related issue**

StaticApiLayerModule, when loading a tile, performs LoadTempTile, then LoadInstant. Both of them call unityTile.ImageContainer.SetImageData, which, upon receiving RasterData, swaps OnDispose delegate. (Removing from old RasterData and adding to a new RasterData). Adding and removing delegates creates allocation, as it creates a new delegate after such an operation. This escalates when loading a lot of tiles at once.
Here is a screenshots from profiler on iPhone 13 Pro Max loading a map at Zoom 18 with TransformBasedTileProviderBehaviour set to 5 in all directions.
Current implementation creates 42KB of allocations and taking almost 11ms of cpu time to proceed
<img width="1368" height="303" alt="Screenshot 2025-09-23 at 10 52 41" src="https://github.com/user-attachments/assets/67e25916-e29f-459c-82d6-daf4f566ee39" />
Changing the Combine/Remove delegate to a direct pass of the delegate resolves the issue, but it can cause issues if someone tries to add to these delegates, as that add can be lost as tiles load/unload. A potential solution if this case needs to be handled is to replace the delegate with an array/list and pass it.
Here is a screenshot of the performance of direct pass for the delegate on the same device and map settings.
<img width="1328" height="265" alt="Screenshot 2025-09-23 at 11 38 45" src="https://github.com/user-attachments/assets/0cdb8ebb-ab41-40b4-b5e9-093304da6ff6" />
I'm not sure if RasterData could be used by multiple UnityTileImageContainers, as in that case, this approach is bad.

**Description of changes**

- MapboxTileData removed the default delegate and replaced OnDispose call with a null propagating invoke.
- UnityTileImageContainer removed the default delegate and replaced += and -= with direct pass
- UnityMapTile replaced += with direct pass delegate(probably doesn't change that much)

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
