### PR TITLE
Clarify nature of missing modifier stack object references, AddModifierStack->AddModifierStacks

### DIFF
--- a/Runtime/Mapbox/VectorModule/IVectorLayerVisualizer.cs
+++ b/Runtime/Mapbox/VectorModule/IVectorLayerVisualizer.cs
@@ -12,7 +12,7 @@ namespace Mapbox.VectorModule
     public interface IVectorLayerVisualizer
     {
         string VectorLayerName { get; }
-        void AddModifierStack(List<ModifierStack> stack);
+        void AddModifierStacks(IEnumerable<ModifierStack> stack);
         Dictionary<int, HashSet<MeshData>> CreateMesh(CanonicalTileId tileId, VectorTileLayer layer);
         List<GameObject> CreateGo(CanonicalTileId tileId, Dictionary<int, HashSet<MeshData>> meshData);
         void UnregisterTile(CanonicalTileId tileId);

--- a/Runtime/Mapbox/VectorModule/IVectorLayerVisualizer.cs
+++ b/Runtime/Mapbox/VectorModule/IVectorLayerVisualizer.cs
@@ -12,7 +12,7 @@ namespace Mapbox.VectorModule
     public interface IVectorLayerVisualizer
     {
         string VectorLayerName { get; }
-        void AddModifierStacks(IEnumerable<ModifierStack> stack);
+        void AddModifierStacks(IEnumerable<ModifierStack> stacks);
         Dictionary<int, HashSet<MeshData>> CreateMesh(CanonicalTileId tileId, VectorTileLayer layer);
         List<GameObject> CreateGo(CanonicalTileId tileId, Dictionary<int, HashSet<MeshData>> meshData);
         void UnregisterTile(CanonicalTileId tileId);

--- a/Runtime/Mapbox/VectorModule/Unity/VectorLayerVisualizerObject.cs
+++ b/Runtime/Mapbox/VectorModule/Unity/VectorLayerVisualizerObject.cs
@@ -32,7 +32,8 @@ namespace Mapbox.VectorModule.Unity
 			{
 				modifierStackObject.Initialize(unityContext);
 			}
-			_layerVisualizer.AddModifierStack(_modifierStackObjects.Select(x => x.GetModifierStack).ToList());
+			_layerVisualizer.AddModifierStacks(_modifierStackObjects.Select((x, i) => x?.GetModifierStack 
+				?? throw new NullReferenceException($"{name} ({nameof(VectorLayerVisualizerObject)}) is missing {nameof(ModifierStackObject)} reference @ element {i}")));
 
 			_layerVisualizer.OnVectorMeshCreated += OnVectorMeshCreated;
 			_layerVisualizer.OnVectorMeshDestroyed += OnVectorMeshDestroyed;

--- a/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
+++ b/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
@@ -108,9 +108,9 @@ namespace Mapbox.VectorModule
             yield return null;
         }
 
-        public void AddModifierStacks(IEnumerable<ModifierStack> stack)
+        public void AddModifierStacks(IEnumerable<ModifierStack> stacks)
         {
-            foreach (var modifierStack in stack)
+            foreach (var modifierStack in stacks)
             {
                 _stackList.Add(modifierStack.GetHashCode(), modifierStack);
             }

--- a/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
+++ b/Runtime/Mapbox/VectorModule/VectorLayerVisualizer.cs
@@ -108,7 +108,7 @@ namespace Mapbox.VectorModule
             yield return null;
         }
 
-        public void AddModifierStack(List<ModifierStack> stack)
+        public void AddModifierStacks(IEnumerable<ModifierStack> stack)
         {
             foreach (var modifierStack in stack)
             {


### PR DESCRIPTION
Apropos of no preexisting issue, for your consideration:

When aggregating ModifierStack objects for VectorLayerVisualizer, it cannot be assumed that all serialized list entries are non-null, as they come from the Editor. Thus, it is benefitial to clarify the reason NullReferenceExceptions are given when iterating over their collection.

Additionally, the AddModifierStack method may add multiple ModifierStack objects, implying that it should be named "AddModifierStacks". Also, it does not need a List to function.

If you have different ideas for the future of AddModifierStack, please close this pull request, and consider the NullReferenceException modification for future scenarios where serialized data is referenced via LINQ or otherwise.

**Description of changes**

VectorLayerVisualizerObject
- LINQ ModifierStackObject aggregating expression tests if stack is null, and if it is, it raises an exception with an explanation of what is null

VectorLayerVisualizer, IVectorLayerVisualizer
- AddModifierStack signature changed to `AddModifierStacks(IEnumerable<ModifierStack> stacks)`

**Reviewers**

@brnkhy 
