### PR TITLE
fix an issue where sdk didn't support medium code stripping setting

### DIFF
--- a/Runtime/Mapbox/BaseModule/Data/Platform/TileJSON/TileJSONReponse.cs
+++ b/Runtime/Mapbox/BaseModule/Data/Platform/TileJSON/TileJSONReponse.cs
@@ -2,6 +2,7 @@
 using Mapbox.BaseModule.Data.Vector2d;
 using Mapbox.BaseModule.Utilities;
 using Newtonsoft.Json;
+using UnityEngine.Scripting;
 
 namespace Mapbox.BaseModule.Data.Platform.TileJSON
 {
@@ -137,6 +138,7 @@ namespace Mapbox.BaseModule.Data.Platform.TileJSON
 		[JsonProperty("webpage")]
 		public string WebPage { get; set; }
 
-
+		[Preserve]
+		public TileJSONResponse() { }
 	}
 }


### PR DESCRIPTION
fix an issue where tilejsonresponse didn't work with medium level code stripping setting due to not having an empty (and preserved/non-stripped) constructor.

before this sdk, sdk supported minimal and low settings for unity3d code-stripping.
with this fix, sdk now should support medium code-stripping settings. 