### PR TITLE
Fix duplicate tile bug

### DIFF
--- a/Runtime/Mapbox/BaseModule/Map/MapboxMapVisualizer.cs
+++ b/Runtime/Mapbox/BaseModule/Map/MapboxMapVisualizer.cs
@@ -166,6 +166,12 @@ namespace Mapbox.BaseModule.Map
         {
             foreach (var tileId in tileCover.Tiles)
             {
+                if (ActiveTiles.TryGetValue(tileId, out var existingTile))
+                {
+                    ShowTile(existingTile);
+                    continue;
+                }
+
                 UnityMapTile unityMapTile = null;
                 if (!CreateTileInstant(tileId, out unityMapTile)) //if we can't fully load the tile
                     CreateTempTile(tileId, out unityMapTile); //we load it whatever data we can find


### PR DESCRIPTION
Prevent LoadSnapshot from creating new tiles that are already loaded. I'm not sure if I'm using the SDK wrong, but without this, I could get duplicate tiles loaded on top of each other.

Here's the chain as reported by Claude:
```

  1. I call m_VisualMap.Initialize(), which fires Initialized → MapInitialized() → starts LoadMapView() as a coroutine on Runnable.Instance
  2. Meanwhile, CommitMapUpdate() is called → Load() runs → gets tiles from the pool, adds them to ActiveTiles, activates them
  3. Later that same frame, LoadMapView's coroutine calls LoadSnapshot()

LoadSnapshot does not check ActiveTiles first — it unconditionally calls _tileCreator.GetTile() (a fresh tile from the pool), positions it, loads data into it, and calls ShowTile. Inside CreateTile, the ActiveTiles.ContainsKey check prevents adding a duplicate to the dictionary, but does not prevent the new tile from being activated. The new tile is then orphaned: active in the scene, at the same world position as the already-active tile from Load(), never to be recycled.
```

I'm not convinced this is the _correct_ fix -- it seems intentional that you don't check ActiveTiles here -- but I don't know what I should be doing instead if not this.