### PR TITLE
Fix/input fix main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ Runtime/Mapbox/VectorModule/MeshGeneration/.idea
 # Internal benchmark tool, kept local-only
 Runtime/Mapbox/Example/Scripts/TileProviderBenchmark.cs
 Runtime/Mapbox/Example/Scripts/TileProviderBenchmark.cs.meta
+
+# Claude Code local config, kept local-only
+CLAUDE.md
+CLAUDE.md.meta
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## CHANGELOG
 
+### v3.1.1
+
+Patch release. Reclassifies `com.unity.inputsystem` from a soft to a **hard** package dependency and switches the example-assembly `#if` gate from package presence to Player Settings, restoring compilation on Unity 6+ projects where the input system package ships preinstalled. Existing legacy-input projects updating from 3.1.0 see no runtime behavior change.
+
+#### Why this exists
+
+In 3.1.0 the SDK declared `com.unity.inputsystem` as a soft dependency: source code branched on a `MAPBOX_NEW_INPUT_SYSTEM` define wired via `versionDefines` (set when the package is installed), but `MapboxExamples.asmdef` did not actually reference `Unity.InputSystem`. On Unity 6+ — where the input system package is installed by default — the `#if MAPBOX_NEW_INPUT_SYSTEM` branch activated, the `using UnityEngine.InputSystem` failed to resolve at the asmdef level, and the entire Examples assembly failed to compile.
+
+The mirror failure mode (asmdef referencing `Unity.InputSystem` without the package installed → unresolved-reference compile error in 2022.3 legacy projects) ruled out simply restoring the reference. Source-side `#if` cannot bridge this because asmdef reference resolution happens before C# preprocessing.
+
+This release resolves the trade-off by treating the package as a hard dependency that's always installed, and gating the source-side branch on a Unity built-in define that's only set when the user explicitly opts in via Player Settings.
+
+#### Changed
+
+- `com.unity.inputsystem` (>= 1.7.0) is declared in `package.json` `dependencies`. UPM auto-installs it on next package refresh. The package coexists with legacy input; installation alone does not change runtime behavior.
+- `PointerInput.cs` now gates on Unity's built-in `ENABLE_INPUT_SYSTEM` define (set by Player → Active Input Handling = "New" or "Both") instead of `MAPBOX_NEW_INPUT_SYSTEM`. Existing legacy-input projects keep running the `#else` branch until the user explicitly switches Active Input Handling.
+- `MapboxExamples.asmdef` references `Unity.InputSystem` directly and drops the `MAPBOX_NEW_INPUT_SYSTEM` `versionDefines` block (no longer used).
+
+#### Upgrading an existing project
+
+For the common case — Unity 2022.3 project, Active Input Handling = "Old", no prior `com.unity.inputsystem` install — no action is required. After the SDK update, UPM installs the input system package (~2 MB), Active Input Handling stays "Old", and every code path runs the same legacy implementation it did before.
+
+If the upgrade goes wrong, in roughly decreasing order of likelihood:
+
+- **Stale compile errors that mention `UnityEngine.InputSystem` or `MAPBOX_NEW_INPUT_SYSTEM`** — Unity's `Library/` cache hasn't picked up the new package. Close Unity, delete `Library/`, reopen. Unity re-resolves packages and reimports.
+- **Package Manager reports "cannot resolve com.unity.inputsystem"** — the project is on Unity < 2022.3, which the SDK does not support, or a project-side `Packages/manifest.json` override pins an incompatible version. Bump the project's Unity version or relax the version constraint.
+- **Map cameras stop responding to mouse / touch after the update** — should not happen if Active Input Handling matches what it was before; if it does, verify Project Settings → Player → Active Input Handling is still set to your prior choice. Unity does not change this setting when a package is auto-installed, but a manual setting flip during the update would explain the symptom.
+- **Yellow Inspector warning on `StandaloneInputModule` asking to "Replace with InputSystemUIInputModule"** — cosmetic, appears only under Active Input Handling = "New" / "Both". One-click swap on the EventSystem inspector if you want to clear it; runtime is unaffected.
+- **UGUI throws `InvalidOperationException: You are trying to read Input using the UnityEngine.Input class…` under Active Input Handling = "New" only** — Unity's default `StandaloneInputModule` reads through `UnityEngine.Input.*`, which throws under New-only. Either set Active Input Handling to "Both" (legacy stays available for UGUI), or click "Replace with InputSystemUIInputModule" on the EventSystem inspector.
+- **You want to remove `com.unity.inputsystem` entirely from your project** — UPM blocks removal because the SDK declares it as a dependency. The de facto opt-out is to leave it installed and set Active Input Handling = "Old"; the package is then dead weight on disk but runtime is identical to legacy-only. For a true physical removal, edit the SDK's `package.json` to drop the `com.unity.inputsystem` line and remove the matching GUID reference from `MapboxExamples.asmdef`. Requires the SDK to be in an editable location (e.g. embedded under `Packages/`, not in `Library/PackageCache/`).
+
 ### v3.1.0
 
 Minor-version bump per semver: this release contains source-breaking API changes (listed below) alongside substantial feature work in camera/input, tile LOD, and terrain rendering. The 3.0.7 designation was previously used in development; published 3.0.7 builds, if any, are superseded by 3.1.0.

--- a/Documentation~/CameraSystem.md
+++ b/Documentation~/CameraSystem.md
@@ -102,12 +102,12 @@ Zoom at cursor works with both mouse and touch — when using pinch, the zoom ce
 
 ## Input System Support
 
-The cameras work with both Unity's legacy Input Manager and the new Input System package. The active path is selected at compile time:
+The cameras work with both Unity's legacy Input Manager and the new Input System package. `com.unity.inputsystem` is a hard dependency of the SDK (UPM installs it automatically), but the active code path is selected by Player Settings, not by package presence:
 
-- **Default (no Input System package installed)** — uses the legacy `UnityEngine.Input` API. No action needed.
-- **With `com.unity.inputsystem` installed** — the example asmdef declares a `versionDefines` entry that automatically defines `MAPBOX_NEW_INPUT_SYSTEM`. The new-input branch activates and reads pointer state via `Mouse.current` / `Touch.activeTouches`.
+- **Active Input Handling = "Input Manager (Old)" (default)** — uses the legacy `UnityEngine.Input` API. No action needed, and this is unchanged by the package being installed.
+- **Active Input Handling = "Input System Package (New)" or "Both"** — Unity defines the built-in `ENABLE_INPUT_SYSTEM` symbol, which activates the new-input branch. Pointer state is read via `Mouse.current` / `Touch.activeTouches`.
 
-The Input System package is *not* a hard dependency of the SDK — projects that don't install it keep the legacy path with no extra setup. Projects that set **Active Input Handling** to "Input System Package (New)" only must install the package; otherwise `UnityEngine.Input` is unavailable at runtime.
+Installing `com.unity.inputsystem` alone does not change which path runs — only flipping Active Input Handling does. See the [CHANGELOG](../CHANGELOG.md#v311) for why the SDK moved from a soft dependency gated on package presence to this model.
 
 ---
 

--- a/Documentation~/Migration-3.0-to-3.1.md
+++ b/Documentation~/Migration-3.0-to-3.1.md
@@ -23,7 +23,7 @@ The new dependency is resolved automatically by UPM:
 | Dependency | Status | Why |
 | --- | --- | --- |
 | `com.unity.burst@1.8.12` | **New required dep** | Terrain-RGB decode and collider vertex fill are now Burst jobs. |
-| `com.unity.inputsystem` | **Soft dep (unchanged)** | If installed, the SDK auto-uses the new Input System via a `MAPBOX_NEW_INPUT_SYSTEM` define from `versionDefines`. If absent, the SDK falls back to legacy `UnityEngine.Input`. No project-side action either way. |
+| `com.unity.inputsystem@1.7.0` | **New required dep (as of v3.1.1)** | Hard dependency, auto-installed by UPM. Which input path runs is controlled by Player Settings → Active Input Handling, not by package presence — see [CameraSystem.md](CameraSystem.md#input-system-support). Projects on "Input Manager (Old)" (the default) see no behavior change. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Resolved automatically by UPM:
 | `com.unity.render-pipelines.universal` | `10.10.1` | Yes | Terrain and building shaders ship as URP Shader Graphs. |
 | `com.unity.nuget.newtonsoft-json` | `3.2.1` | Yes | JSON parsing for tile metadata and API responses. |
 | `com.unity.burst` | `1.8.12` | Yes | Burst-compiled terrain decode and collider job. First-time domain reload pays a one-shot AOT compile. |
-| `com.unity.inputsystem` | any | Optional | If installed, camera input uses the new Input System (auto-set `MAPBOX_NEW_INPUT_SYSTEM` define). If absent, falls back to legacy `UnityEngine.Input`. |
+| `com.unity.inputsystem` | `1.7.0` | Yes | Camera input backend selection is controlled by Player Settings → Active Input Handling, not by this dependency; "Old" (default) keeps legacy `UnityEngine.Input` behavior. See `Documentation~/CameraSystem.md`. |
 
 ---
 

--- a/Runtime/Mapbox/Example/MapboxExamples.asmdef
+++ b/Runtime/Mapbox/Example/MapboxExamples.asmdef
@@ -8,7 +8,8 @@
         "GUID:36ca6af6e2b304d4090888554d6ce199",
         "GUID:1b64b068a01f943108c7f4b7a5356c7a",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:8ba268152fd3143f59445711358cb12f"
+        "GUID:8ba268152fd3143f59445711358cb12f",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -17,12 +18,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.unity.inputsystem",
-            "expression": "",
-            "define": "MAPBOX_NEW_INPUT_SYSTEM"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Runtime/Mapbox/Example/Scripts/PointerInput.cs
+++ b/Runtime/Mapbox/Example/Scripts/PointerInput.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if MAPBOX_NEW_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 using NewTouch = UnityEngine.InputSystem.EnhancedTouch.Touch;
 using NewTouchPhase = UnityEngine.InputSystem.TouchPhase;
@@ -24,10 +24,15 @@ namespace Mapbox.Example.Scripts.MapInput
 
 	/// <summary>
 	/// Thin abstraction over Unity's two input backends. <see cref="PointerInput"/>
-	/// has exactly one of two implementations compiled in, selected by the
-	/// MAPBOX_NEW_INPUT_SYSTEM define (which the asmdef's versionDefines sets when
-	/// com.unity.inputsystem is installed). MapInput.cs talks only to this interface,
-	/// so the rest of the camera/input layer stays free of #if branching.
+	/// has exactly one of two implementations compiled in, selected by Unity's
+	/// built-in <c>ENABLE_INPUT_SYSTEM</c> define (set when Active Input Handling
+	/// in Player Settings is "New" or "Both"). Gating on <c>ENABLE_INPUT_SYSTEM</c>
+	/// rather than package presence is intentional: <c>com.unity.inputsystem</c> is
+	/// a hard dependency of this package, so it's always installed, but existing
+	/// legacy-input projects must keep running the <c>#else</c> branch until the
+	/// user explicitly opts in via Active Input Handling. MapInput.cs talks only
+	/// to this interface, so the rest of the camera/input layer stays free of
+	/// #if branching.
 	/// </summary>
 	internal interface IPointerInput
 	{
@@ -62,7 +67,7 @@ namespace Mapbox.Example.Scripts.MapInput
 		float MouseScrollY { get; }
 	}
 
-#if MAPBOX_NEW_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM
 	internal sealed class PointerInput : IPointerInput
 	{
 		public void EnableTouchSupport()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.mapbox.sdk",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "displayName": "Mapbox Unity SDK",
     "description": "Mapbox Unity SDK",
     "unity": "2022.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dependencies": {
         "com.unity.render-pipelines.universal": "10.10.1",
 	"com.unity.nuget.newtonsoft-json": "3.2.1",
-	"com.unity.burst": "1.8.12"
+	"com.unity.burst": "1.8.12",
+	"com.unity.inputsystem": "1.7.0"
     },
     "author": {
         "name": "Mapbox",


### PR DESCRIPTION
Summary:
On newer Unity projects (Unity 6 and up), this package failed to compile because of how we handled the optional Input System package. This PR makes the dependency explicit and reliable, so the SDK now builds correctly regardless of which input setup a project uses.

What changed:

com.unity.inputsystem is now a proper package dependency, so Unity always installs it alongside the SDK.
Input handling now follows the project's own Player Settings (Active Input Handling) instead of guessing based on whether a package happens to be installed.
Updated docs/README to match the new behavior.
Impact on existing projects:
No action needed. Projects using the old (legacy) input setup will keep working exactly as before — this only fixes projects that were previously broken by the compile error.

Bumped to v3.1.1 with changelog notes for anyone upgrading.

@flasher297